### PR TITLE
Needed a strict, just the valid ISBN field for Google Book API covers…

### DIFF
--- a/lib/traject/psulib_config.rb
+++ b/lib/traject/psulib_config.rb
@@ -69,7 +69,7 @@ to_field 'isbn_sim', extract_marc('020az', separator: nil) do |_record, accumula
   accumulator.uniq!
 end
 
-to_field('isbn_valid_ssm', extract_marc("020a", separator: nil)) do |_record, accumulator|
+to_field('isbn_valid_ssm', extract_marc('020a', separator: nil)) do |_record, accumulator|
   accumulator.map! { |x| StdNum::ISBN.allNormalizedValues(x) }
   accumulator.flatten!
   accumulator.uniq!

--- a/lib/traject/psulib_config.rb
+++ b/lib/traject/psulib_config.rb
@@ -69,6 +69,12 @@ to_field 'isbn_sim', extract_marc('020az', separator: nil) do |_record, accumula
   accumulator.uniq!
 end
 
+to_field('isbn_valid_ssm', extract_marc("020a", separator: nil)) do |_record, accumulator|
+  accumulator.map! { |x| StdNum::ISBN.allNormalizedValues(x) }
+  accumulator.flatten!
+  accumulator.uniq!
+end
+
 to_field 'isbn_ssm', extract_marc('020aqz', separator: ' ', trim_punctuation: true)
 
 ## ISSN


### PR DESCRIPTION
… (this produces two, a 10 and a 13 ISBN)

Required by https://github.com/psu-libraries/psulib_blacklight/pull/345