### PR TITLE
The default setting in Traject is to send a hard commit with a timeou…

### DIFF
--- a/config/indexer_settings_dev.yml
+++ b/config/indexer_settings_dev.yml
@@ -10,3 +10,4 @@ reader_class_name: Traject::MarcCombiningReader
 marc4j_reader_permissive: true
 marc4j_reader_source_encoding: UTF-8
 processing_thread_pool: 5
+commit_timeout: 10000

--- a/config/indexer_settings_production.yml
+++ b/config/indexer_settings_production.yml
@@ -10,3 +10,4 @@ reader_class_name: Traject::MarcCombiningReader
 marc4j_reader_permissive: true
 marc4j_reader_source_encoding: UTF-8
 processing_thread_pool: 7
+commit_timeout: 900

--- a/config/indexer_settings_qa.yml
+++ b/config/indexer_settings_qa.yml
@@ -10,3 +10,4 @@ reader_class_name: Traject::MarcCombiningReader
 marc4j_reader_permissive: true
 marc4j_reader_source_encoding: UTF-8
 processing_thread_pool: 7
+commit_timeout: 10000

--- a/lib/traject/psulib_config.rb
+++ b/lib/traject/psulib_config.rb
@@ -35,9 +35,10 @@ settings do
   provide 'log.batch_size', indexer_settings['log_batch_size']
   provide 'solr.version', indexer_settings['solr_version']
   provide 'log.file', indexer_settings['log_file']
-  provide 'log.error_file', indexer_settings['Log_error_file']
+  provide 'log.error_file', indexer_settings['log_error_file']
   provide 'solr_writer.commit_on_close', indexer_settings['solr_writer_commit_on_close']
   provide 'reader_class_name', indexer_settings['reader_class_name']
+  provide 'commit_timeout', indexer_settings['commit_timeout']
 
   if is_jruby
     provide 'marc4j_reader.permissive', indexer_settings['marc4j_reader_permissive']


### PR DESCRIPTION
…t at 60 seconds. This will change that to 10,000 seconds for QA and Dev and 900 seconds (15 minutes) for Prod. We should watch performance during hourlies to note how hard commits are affecting system performance and consider changing to softCommit if necessary.

Additional change, lowercasing a random capital "L"

Related to issue https://github.com/psu-libraries/psulib_blacklight/issues/286