### PR TITLE
Replaces coveralls with code climate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,22 @@ rvm:
   - jruby-9.2.4.0
 sudo: false
 
+env:
+  global:
+    - CC_TEST_REPORTER_ID=07da8f2c9c45d37c15805939c790c778c49a170181ade9ad453ad6cb1f13bbfd
+
+branches:
+  only:
+    - master
+
 before_install:
   - gem update --system
   - gem install bundler
 
 before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
   - docker pull solr:7.4.0
   - docker run -d -p 8983:8983 -v "$(pwd)"/solr/conf:/myconfig solr:7.4.0 solr-create -c psul_blacklight -d /myconfig
   - docker ps -a
@@ -16,5 +27,8 @@ cache:
   bundler: true
 
 script:
-- bundle exec rubocop
-- bundle exec rake
+  - bundle exec rubocop
+  - bundle exec rake
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'coveralls', require: false
 gem 'library_stdnums'
 gem 'mail'
 gem 'marc'
@@ -16,5 +15,5 @@ group :development, :test do
   gem 'byebug', platform: :mri
   gem 'rspec'
   gem 'rubocop'
-  gem 'ruby-debug', platform: :jruby
+  gem 'simplecov'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,14 +6,7 @@ GEM
     ast (2.4.0)
     builder (3.2.4)
     chronic (0.10.2)
-    columnize (0.9.0)
     concurrent-ruby (1.1.6)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     diff-lcs (1.3)
     docile (1.3.2)
     domain_name (0.5.20190701)
@@ -32,9 +25,7 @@ GEM
     http-form_data (2.3.0)
     http_parser.rb (0.6.0-java)
     httpclient (2.8.3)
-    json (2.3.0-java)
     library_stdnums (1.6.0)
-    linecache (1.3.1-java)
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marc (1.0.4)
@@ -80,25 +71,13 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-ast (0.0.3)
       parser (>= 2.7.0.1)
-    ruby-debug (0.11.0)
-      columnize (>= 0.1)
-      linecache (~> 1.3.1)
-      ruby-debug-base (~> 0.11.0.0)
-    ruby-debug-base (0.11.0-java)
     ruby-progressbar (1.10.1)
     scrub_rb (1.0.1)
-    simplecov (0.16.1)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     slop (3.6.0)
-    sync (0.5.0)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
-    thor (1.0.1)
-    tins (1.25.0)
-      sync
     traject (3.1.0)
       concurrent-ruby (>= 0.8.0)
       dot-properties (>= 0.1.1)
@@ -124,7 +103,6 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
-  coveralls
   library_stdnums
   mail
   marc
@@ -132,7 +110,7 @@ DEPENDENCIES
   rsolr
   rspec
   rubocop
-  ruby-debug
+  simplecov
   traject (= 3.1.0)
   traject-marc4j_reader
   whenever

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
+[![Maintainability](https://api.codeclimate.com/v1/badges/f877d0681e38deb0f3c8/maintainability)](https://codeclimate.com/github/psu-libraries/psulib_traject/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/f877d0681e38deb0f3c8/test_coverage)](https://codeclimate.com/github/psu-libraries/psulib_traject/test_coverage)
+
 # psulib_traject
+
 ## Dependencies
+
 ### Java
 To run JRuby you will need a JRE (the JVM runtime environment) version 7 or higher.
 ```

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
-
-require 'coveralls'
-Coveralls.wear!
+require 'simplecov'
+SimpleCov.start
 
 require 'rspec'
 require 'traject'


### PR DESCRIPTION
additionally I removed a gem called `ruby-debug` because it kept giving this error below and I didn't think we used it anyway:

```
➜  psulib_traject git:(codeclimate) ✗ bundle exec rake
jruby: warning: unknown property jruby.cext.enabled
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by org.jruby.util.SecurityHelper to field java.lang.reflect.Field.modifiers
WARNING: Please consider reporting this to the maintainers of org.jruby.util.SecurityHelper
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
sBundler could not find compatible versions for gem "linecache":
  In snapshot (Gemfile.lock):
    linecache (= 1.3.1)

  In Gemfile:
    ruby-debug java was resolved to 0.10.6, which depends on
      linecache (~> 1.3.1) java

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```