### PR TITLE
Makes logs easier to parse and monitor with Splunk

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,7 @@ solr_writer:
   commit_on_close: true
 reader_class_name: Traject::MarcCombiningReader
 commit_timeout: 10000
+symphony_data_path: /data/symphony_data/
 hathi_overlap_path: /data/hathitrust_data/
 hathi_etas: true
 marc4j_reader:


### PR DESCRIPTION
* Also adds a new config gem setting to replace the random symphony path constant

#203 

The idea will be that we can create a monitor that expects these parsed messages to occur at various times a day, or by total count in a day, or something like that. There are different options I think, but, bottom line is it gets us a view on our incrementals that Splunk can alert us about without us having to try and wire up some directory watching service or emailing directly from code, etc.

Might be a good idea to do a test deploy and see if it does to the logs what I'm hoping it does. Locally it did this:

```
2020-09-30T22:15:35-04:00  INFO name=Sirsi Incremental message=Indexing operation beginning task=hourly import progress=start
2020-09-30T22:15:35-04:00  INFO jruby 9.2.11.1 (2.5.7) 2020-03-25 b1f55b1a40 Java HotSpot(TM) 64-Bit Server VM 11+28 on 11+28 +jit [darwin-x86_64]
2020-09-30T22:15:36-04:00  INFO name=Sirsi Incremental message=Indexing ["ignorethis_marc/hourly_dev/hourly_addupdate_201906131300.mrc"] task=hourly import progress=in progress
2020-09-30T22:15:36-04:00  INFO    Traject::SolrJsonWriter writing to 'http://localhost:8983/solr/psul_blacklight/update/json' in batches of 100 with 1 bg threads
2020-09-30T22:15:36-04:00  INFO    Traject::Indexer with 5 processing threads, reader: Traject::MarcCombiningReader and writer: Traject::SolrJsonWriter
2020-09-30T22:15:38-04:00  INFO Traject::SolrJsonWriter sending commit to solr at url http://localhost:8983/solr/psul_blacklight/update/json...
2020-09-30T22:15:40-04:00  INFO finished Traject::Indexer#process: 505 records in 4.274 seconds; 118.1 records/second overall.
2020-09-30T22:15:40-04:00  INFO name=Sirsi Incremental message=Indexed ignorethis_marc/hourly_dev/hourly_addupdate_201906131300.mrc task=hourly import progress=done
```