### PR TITLE
Fixup

### DIFF
--- a/lib/tasks/incrementals.rake
+++ b/lib/tasks/incrementals.rake
@@ -8,11 +8,11 @@ namespace :incrementals do
   desc 'Adds to the index'
   task :import, [:period] do |_task, args|
     indexer = Traject::Indexer::MarcIndexer.new
+    indexer.load_config_file('lib/traject/psulib_config.rb')
     indexer.logger.info 'name="Sirsi Incremental" '\
                         'message="Indexing operation beginning" '\
                         "task=\"#{args[:period]} import\" "\
                         'progress=start'
-    indexer.load_config_file('lib/traject/psulib_config.rb')
     target = Dir["#{ConfigSettings.symphony_data_path}#{args[:period]}_#{ENV['RUBY_ENVIRONMENT']}/*.mrc"]
 
     if target.empty?


### PR DESCRIPTION
Mistakenly calling `.info` before loading the config sends logs to `STDOUT`