### PR TITLE
Adds a specific value for required memory

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 set :environment_variable, 'RUBY_ENVIRONMENT'
+# Overrides the default :rake job type of
+# job_type :rake,    "cd :path && :environment_variable=:environment bundle exec rake :task --silent :output"
+job_type :rake,    "cd :path && JRUBY_OPTS=\"-J-Xmx4028m\" :environment_variable=:environment bundle exec rake :task --silent :output"
 
 # Process incrementals (adds/deletes from Symphony) daily
 # Changes to this schedule should be reflected in the "Traject Incrementals (daily)" alert in splunk


### PR DESCRIPTION
locally I ran `whenever` after this and got 

```
10 4 * * * /bin/bash -l -c 'cd /Users/cdm32/Projects/ruby/psulib_traject && JRUBY_OPTS="-J-Xmx4028m" RUBY_ENVIRONMENT=production bundle exec rake incrementals:import['\''daily'\''] --silent'

10 4 * * * /bin/bash -l -c 'cd /Users/cdm32/Projects/ruby/psulib_traject && JRUBY_OPTS="-J-Xmx4028m" RUBY_ENVIRONMENT=production bundle exec rake incrementals:delete['\''daily'\''] --silent'

3 0,7-23 * * * /bin/bash -l -c 'cd /Users/cdm32/Projects/ruby/psulib_traject && JRUBY_OPTS="-J-Xmx4028m" RUBY_ENVIRONMENT=production bundle exec rake incrementals:import['\''hourly'\''] --silent'

3 0,7-23 * * * /bin/bash -l -c 'cd /Users/cdm32/Projects/ruby/psulib_traject && JRUBY_OPTS="-J-Xmx4028m" RUBY_ENVIRONMENT=production bundle exec rake incrementals:delete['\''hourly'\''] --silent'
```

which looks right to me.

more info at https://github.com/javan/whenever#define-your-own-job-types

there are other ways to solve this with this gem, but this seemed ok to me

h/t to @whereismyjetpack for helping diagnose