### PR TITLE
Add build to CircleCI with test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2.1
+orbs:
+  ruby: circleci/ruby@0.1.2 
+
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.7.1
+    steps:
+      - checkout
+      - run:
+          name: Install Gems
+          command: bundle install
+      - run:
+          name: RSpec
+          command: bundle exec rspec
+      - run:
+          name: Upload Coverage
+          when: on_success
+          command: |
+            wget -q https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 -O cc-test-reporter
+            chmod 755 cc-test-reporter
+            export TAG=${CIRCLE_SHA1}
+            export GIT_COMMIT_SHA=$CIRCLE_SHA1
+            export GIT_BRANCH=$CIRCLE_BRANCH
+            export GIT_COMMITED_AT=$(git log -1 --date=short --pretty=format:%ct)
+            ./cc-test-reporter after-build -d


### PR DESCRIPTION
Tests the project in CircleCI and sends coverage reports to Code Climate.

Fixes #274 