### PR TITLE
Update Docker and Solr related tasks

### DIFF
--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -20,8 +20,8 @@ namespace :docker do
 
   task :clean do
     print `docker exec -it felix \
-            post -c psul_blacklight \
-                 -d '<delete><query>*:*</query></delete>' -out 'yes'`
+            post -c psul_catalog \
+                 -d '<delete><query>*:*</query></delete>'`
   end
 
   task :first_start do
@@ -31,7 +31,7 @@ namespace :docker do
             -p 8983:8983 \
             -v "$(pwd)"/solr/conf:/myconfig \
             solr:7.4.0 \
-            solr-create -c psul_blacklight -d /myconfig`
+            solr-create -c psul_catalog -d /myconfig`
   end
 
   task :pull do
@@ -44,7 +44,7 @@ namespace :docker do
 
   task :conf do
     print `docker exec -it felix \
-            cp -R /myconfig/. /opt/solr/server/solr/psul_blacklight/conf/`
+            cp -R /myconfig/. /opt/solr/server/solr/psul_catalog/conf/`
   end
 
   task :down do

--- a/lib/tasks/solr.rake
+++ b/lib/tasks/solr.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'faraday'
+
 namespace :solr do
   desc 'Updates solr config files from psulib_blacklight'
   task :conf do


### PR DESCRIPTION
Changes the Docker rake tasks to use "psul_catalog" as the collection name, which matches the name in settings.yml. The solr tasks file is renamed to "solr" to lineup with the namespace.