### PR TITLE
Load jruby debugger accordingly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 
 group :development, :test do
   gem 'pry'
-  gem 'pry-debugger-jruby'
+  gem 'pry-debugger-jruby', platform: :jruby
   gem 'rspec'
   gem 'rubocop', '~> 0.79'
   gem 'rubocop-performance', '~> 1.1'


### PR DESCRIPTION
We can run either MRI or JRuby locally depending on our needs.

Switching back and forth between jruby and MRI will change the lock file, but this way, you can just not commit and changes and flip back more easily.