### PR TITLE
Configure Solr's port

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,66 +7,83 @@
 
 ### Java
 To run JRuby you will need a JRE (the JVM runtime environment) version 7 or higher.
-```
-$ java --version
-  java 9
-  Java(TM) SE Runtime Environment (build 9+181)
-  Java HotSpot(TM) 64-Bit Server VM (build 9+181, mixed mode)
-```
+
+    $ java --version
+      java 9
+      Java(TM) SE Runtime Environment (build 9+181)
+      Java HotSpot(TM) 64-Bit Server VM (build 9+181, mixed mode)
 
 ### Ruby
-Follow these instructions to [install JRuby](https://github.com/psu-libraries/psulib_traject/wiki/Install-JRuby) if you do not already have it.
-```
-$ ruby --version
-  jruby 9.2.11.1
-```
+Follow these instructions to [install JRuby](https://github.com/psu-libraries/psulib_traject/wiki/Install-JRuby) if you
+do not already have it.
+
+    $ ruby --version
+      jruby 9.2.11.1
 
 ## Development Setup
 
-1.  [Make sure you have ssh keys established on your machine](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/#generating-a-new-ssh-key)
-1.  [Make sure you have docker installed and running](https://docs.docker.com/install/)
-1.  Clone the application and install.
-    ``` 
+[Make sure you have ssh keys established on your machine](https://help.github.com/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent/#generating-a-new-ssh-key)
+
+[Make sure you have docker installed and running](https://docs.docker.com/install/)
+
+Clone the application and install:
+
     $ git clone git@github.com:psu-libraries/psulib_traject.git
     $ cd psulib_traject
     $ bundle install
-    ```
+
+## Configuration
+
+For local development, you can change the settings by adding configuration files. These will be ignored by git.
+
+### Solr
+
+Create 2 files: `config/settings.local.yml` and `config/test/test.local.yml` and add the following lines to each:
+    
+    solr:
+      url: http://localhost:8983/solr/
+      port: 8983
+
+Change the URL and port numbers if you want to use a different port.
+
+### Traject
+
+When using jruby, traject will use multiple threads, but we want to tailor that to our system. In
+`config/settings.local.yml` add:
+
+    hathi_overlap_path: spec/fixtures/hathitrust/overlap.tsv
+    processing_thread_pool: 5
    
 ## Build an Index
 
-1. Solr config files need to be copied from [psulib_blacklight](https://github.com/psu-libraries/psulib_blacklight/tree/master/solr/conf):
+Start Solr via the Docker container
     
-    ```
-    $ bundle exec rake solr:conf
-    ```
-   
-1. Start Solr
+    $ bundle exec rake docker:up
 
-    If Docker Solr isn't running (check `docker ps`) run
+This will download and configure Solr, if it's not already present, or if it is, start up the container again.
+If you need to reconfigure Solr:
 
-    ```
-    $ bundle exec rake solr:up
-    ```
+    $ bundle exec rake docker:clean
+    $ bundle exec rake docker:conf
     
-1. Convert marc records and import into Solr
+Convert marc records and import into Solr
 
-   ```
-   $ bundle exec traject -c config/traject.rb solr/sample_data/sample_psucat.mrc 
-   ```
+    $ bundle exec traject -c config/traject.rb solr/sample_data/sample_psucat.mrc 
    
-   You can download [other sample files from Box](https://psu.app.box.com/folder/53004724072).
+You can download [other sample files from Box](https://psu.app.box.com/folder/53004724072).
    
 ## Traject in debug mode
 
 For testing purposes you can run traject with the `--debug-mode` flag to
 display the output to the console (and not push the data to Solr).
 
-```
-$ bundle exec traject --debug-mode -c config/traject.rb solr/sample_data/sample_psucat.mrc
-```
+    $ bundle exec traject --debug-mode -c config/traject.rb solr/sample_data/sample_psucat.mrc
 
 ## HathiTrust ETAS data
 
-HathiTrust access level can be recorded in `ht_access_ss`. It will expect to have an overlap report tsv from HathiTrust at `ConfigSettings.hathi_overlap_path`. This file should be the latest overlap report from HathiTrust.
+HathiTrust access level can be recorded in `ht_access_ss`. It will expect to have an overlap report tsv from HathiTrust
+at `ConfigSettings.hathi_overlap_path`. This file should be the latest overlap report from HathiTrust.
 
-Because the monthly overlap file lives in a restricted area that can only be accessed by signing in to Box at UMich, we will need to manually set the overlap.tsv prior to indexing operations when there is a new overlap. This can be done by `scp`ing the file up to the location specified in `ConfigSettings.hathi_overlap_path`.
+Because the monthly overlap file lives in a restricted area that can only be accessed by signing in to Box at UMich, we
+will need to manually set the overlap.tsv prior to indexing operations when there is a new overlap. This can be done by
+`scp`ing the file up to the location specified in `ConfigSettings.hathi_overlap_path`.

--- a/spec/lib/psulib_traject/solr_manager_spec.rb
+++ b/spec/lib/psulib_traject/solr_manager_spec.rb
@@ -6,10 +6,16 @@ require 'config'
 RSpec.describe PsulibTraject::SolrManager do
   subject(:solr_manager) { described_class.new }
 
+  let(:port) { ConfigSettings.solr.port || '8983' }
+
   describe '#last_incremented_collection' do
     before do
-      stub_request(:get, 'http://localhost:8983/solr/admin/collections?action=LIST')
-        .to_return(status: 200, body: '{"responseHeader":{"status":0,"QTime":0},"collections":["psul_catalog_v1","psul_catalog_v2"]}', headers: {})
+      stub_request(:get, "http://localhost:#{port}/solr/admin/collections?action=LIST")
+        .to_return(
+          status: 200,
+          body: '{"responseHeader":{"status":0,"QTime":0},"collections":["psul_catalog_v1","psul_catalog_v2"]}',
+          headers: {}
+        )
     end
 
     it 'emits the last incremented collection' do


### PR DESCRIPTION
This allows us to run Solr on a different port, which is helpful if you have multiple apps running with their own Solr, or want to test different versions on different ports.

This will likely all go away when we have a proper Docker compose setup, but this is mostly for me so I can run Scholarsphere and the catalog simultaneously.