### PR TITLE
updates lockfile for versions of jruby we're using in docker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,10 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry (0.13.1-java)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      spoon (~> 0.0)
     pry-debugger-jruby (2.0.0-java)
       pry (>= 0.13, < 0.14)
       ruby-debug-base (>= 0.10.4, < 0.12)
@@ -194,6 +198,8 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     slop (4.9.1)
+    spoon (0.0.6)
+      ffi
     thwait (0.2.0)
       e2mmap
     tilt (2.0.10)
@@ -228,6 +234,7 @@ GEM
 
 PLATFORMS
   universal-java-11
+  universal-java-14
   x86_64-darwin-20
   x86_64-linux
 


### PR DESCRIPTION
I'm not sure what went sideways here, but syncing it up