### PR TITLE
Return explicit shelf key types in struct

### DIFF
--- a/config/traject.rb
+++ b/config/traject.rb
@@ -294,7 +294,7 @@ each_record do |record, context|
   context.add_output('call_number_lc_ssm', *call_numbers.map(&:value))
   context.add_output('forward_lc_shelfkey', *call_numbers.map(&:forward_shelfkey))
   context.add_output('reverse_lc_shelfkey', *call_numbers.map(&:reverse_shelfkey))
-  context.add_output('keymap_struct', *call_numbers.map(&:keymap).reduce(&:merge).to_json)
+  context.add_output('keymap_struct', *call_numbers.map(&:keymap).to_json)
 end
 
 # Material Characteristics

--- a/lib/psulib_traject/call_number.rb
+++ b/lib/psulib_traject/call_number.rb
@@ -34,8 +34,9 @@ module PsulibTraject
 
     def keymap
       {
-        forward_shelfkey => value,
-        reverse_shelfkey => value
+        'call_number' => value,
+        'forward_key' => forward_shelfkey,
+        'reverse_key' => reverse_shelfkey
       }
     end
 

--- a/spec/lib/psulib_traject/call_number_spec.rb
+++ b/spec/lib/psulib_traject/call_number_spec.rb
@@ -93,8 +93,9 @@ RSpec.describe PsulibTraject::CallNumber do
     its(:keymap) do
       is_expected.to eq(
         {
-          'AB.0123.C456.2000' => 'AB123 .C456 2000',
-          'PO.ZYXW.NVUT.XZZZ~' => 'AB123 .C456 2000'
+          'call_number' => 'AB123 .C456 2000',
+          'forward_key' => 'AB.0123.C456.2000',
+          'reverse_key' => 'PO.ZYXW.NVUT.XZZZ~'
         }
       )
     end


### PR DESCRIPTION
The keymap_struct needs to indicate which key is the forward and reverse key. This will allow to us build the correct list when retrieving them from Solr in the catalog.

Related to #285 