### PR TITLE
NullKey for unparseable LC call numbers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,7 @@ Lint/MissingSuper:
     - 'lib/psulib_traject/processors/call_number/dewey.rb'
     - 'lib/psulib_traject/processors/call_number/lc.rb'
     - 'lib/psulib_traject/processors/call_number/other.rb'
+    - 'lib/psulib_traject/null_object.rb'
 
 Lint/MixedRegexpCaptureTypes:
   Exclude:

--- a/lib/psulib_traject.rb
+++ b/lib/psulib_traject.rb
@@ -18,6 +18,7 @@ module PsulibTraject
   require 'psulib_traject/holdings'
   require 'psulib_traject/macros'
   require 'psulib_traject/marc_combining_reader'
+  require 'psulib_traject/null_object'
   require 'psulib_traject/processors/access_facet'
   require 'psulib_traject/processors/call_number/base'
   require 'psulib_traject/processors/call_number/dewey'

--- a/lib/psulib_traject/null_object.rb
+++ b/lib/psulib_traject/null_object.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module PsulibTraject
+  class NullObject
+    def respond_to_missing?(*)
+      self
+    end
+
+    def method_missing(*)
+      self
+    end
+
+    def nil?
+      true
+    end
+    alias :blank? :nil?
+    alias :empty? :nil?
+  end
+end

--- a/lib/psulib_traject/shelf_key.rb
+++ b/lib/psulib_traject/shelf_key.rb
@@ -5,6 +5,8 @@ module PsulibTraject
     FORWARD_CHARS = ('0'..'9').to_a + ('A'..'Z').to_a
     CHAR_MAP = FORWARD_CHARS.zip(FORWARD_CHARS.reverse).to_h
 
+    class NullKey < NullObject; end
+
     attr_reader :call_number
 
     # @param [String] call_number
@@ -15,7 +17,7 @@ module PsulibTraject
 
     # @return [String]
     def forward
-      Lcsort.normalize(call_number) || default_forward_key
+      Lcsort.normalize(call_number) || NullKey.new
     end
 
     # @return [String]
@@ -26,11 +28,5 @@ module PsulibTraject
         .append('~')
         .join
     end
-
-    private
-
-      def default_forward_key
-        call_number.upcase.gsub(/ /, '.')
-      end
   end
 end

--- a/spec/lib/psulib_traject/null_object_spec.rb
+++ b/spec/lib/psulib_traject/null_object_spec.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+RSpec.describe PsulibTraject::NullObject do
+  it { is_expected.to be_nil }
+  its(:respond_to_missing?) { is_expected.to be_nil }
+  its(:method_missing) { is_expected.to be_nil }
+end

--- a/spec/lib/psulib_traject/shelf_key_spec.rb
+++ b/spec/lib/psulib_traject/shelf_key_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe PsulibTraject::ShelfKey do
   context 'with a number that Lcsort cannot process' do
     let(:call_number) { 'Fiction G758thefu 2015' }
 
-    its(:forward) { is_expected.to eq('FICTION.G758THEFU.2015') }
-    its(:reverse) { is_expected.to eq('KHN6HBC.JSUR6ILK5.XZYU~') }
+    its(:forward) { is_expected.to be_nil }
+    its(:reverse) { is_expected.to be_nil }
   end
 end


### PR DESCRIPTION
If we can't determine a proper shelf key, we need to return nil. Otherwise, querying on shelf keys that have bad characters in them will cause errors in Solr

I've tested this with our catalog's call number branch, and this doesn't seem to break anything, and it should fix the errors we're seeing with Solr queries. All of the LC numbers that have bad characters in them, ex (?:, are all in call numbers that Lcsort can't process. Returning nothing is the better option here. Later, we can attempt to try our own process for this call numbers.

Related to #285 