### PR TITLE
Rubocop and RSpec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,9 @@ jobs:
             gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
             bundle install
       - run:
+          name: Linting
+          command: bundle exec rubocop
+      - run:
           name: RSpec
           command: |
             export REDIS_URL=redis://localhost:6379/1

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
+--format documentation
 --require spec_helper

--- a/spec/lib/psulib_traject/workers/hourly_indexer_spec.rb
+++ b/spec/lib/psulib_traject/workers/hourly_indexer_spec.rb
@@ -2,7 +2,6 @@
 
 require 'spec_helper'
 
-
 RSpec.describe PsulibTraject::Workers::HourlyIndexer do
   let(:indexer) { described_class }
 

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -7,10 +7,10 @@ require 'sidekiq/testing/inline'
 Sidekiq::Testing.fake!
 
 RSpec::Sidekiq.configure do |conf|
-    # Clears all job queues before each example
-    conf.clear_all_enqueued_jobs = true # default => true
-    # Whether to use terminal colours when outputting messages
-    conf.enable_terminal_colours = true # default => true
-    # Warn when jobs are not enqueued to Redis but to a job array
-    conf.warn_when_jobs_not_processed_by_sidekiq = false # default => true
+  # Clears all job queues before each example
+  conf.clear_all_enqueued_jobs = true # default => true
+  # Whether to use terminal colours when outputting messages
+  conf.enable_terminal_colours = true # default => true
+  # Warn when jobs are not enqueued to Redis but to a job array
+  conf.warn_when_jobs_not_processed_by_sidekiq = false # default => true
 end


### PR DESCRIPTION
This makes two small changes:

1. Add rubocop to the CI build (also corrects outstanding linting errors)
2. Use `--format documentation` for RSpec because it creates a more readable output