### PR TITLE
Update local and periodical exclusion rules

### DIFF
--- a/lib/psulib_traject/call_number.rb
+++ b/lib/psulib_traject/call_number.rb
@@ -41,7 +41,7 @@ module PsulibTraject
     end
 
     def periodical?
-      value == 'Periodical'
+      value.match?(/^\^?Periodical/i)
     end
 
     def newspaper?
@@ -49,7 +49,7 @@ module PsulibTraject
     end
 
     def local?
-      value.start_with?('xx(')
+      value.match?(/^xx/i)
     end
 
     def on_order?

--- a/spec/lib/psulib_traject/call_number_spec.rb
+++ b/spec/lib/psulib_traject/call_number_spec.rb
@@ -3,8 +3,18 @@
 require 'spec_helper'
 
 RSpec.describe PsulibTraject::CallNumber do
-  context "when value is 'Periodical'" do
-    subject { described_class.new(value: 'Periodical') }
+  context "when value starts with 'Periodical'" do
+    subject { described_class.new(value: 'Periodical Something') }
+
+    it { is_expected.to be_periodical }
+    it { is_expected.not_to be_newspaper }
+    it { is_expected.not_to be_local }
+    it { is_expected.not_to be_on_order }
+    it { is_expected.to be_exclude }
+  end
+
+  context "when value starts with '^Periodical'" do
+    subject { described_class.new(value: '^Periodical blah') }
 
     it { is_expected.to be_periodical }
     it { is_expected.not_to be_newspaper }
@@ -25,6 +35,16 @@ RSpec.describe PsulibTraject::CallNumber do
 
   context "when value starts with 'xx('" do
     subject { described_class.new(value: 'xx(asdf1234)') }
+
+    it { is_expected.not_to be_periodical }
+    it { is_expected.not_to be_newspaper }
+    it { is_expected.to be_local }
+    it { is_expected.not_to be_on_order }
+    it { is_expected.to be_exclude }
+  end
+
+  context "when value starts with 'XX('" do
+    subject { described_class.new(value: 'XX(asdf1234)') }
 
     it { is_expected.not_to be_periodical }
     it { is_expected.not_to be_newspaper }

--- a/spec/lib/psulib_traject/holdings_spec.rb
+++ b/spec/lib/psulib_traject/holdings_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe PsulibTraject::Holdings do
     end
 
     context 'with a periodical record' do
-      let(:fields) { [MARC::DataField.new('949', '', '', ['a', 'Periodical'])] }
+      let(:fields) { [MARC::DataField.new('949', '', '', ['a', 'Periodical Fiche v.17-v.40'])] }
 
       it { is_expected.to be_empty }
     end


### PR DESCRIPTION
Records with local and periodical call numbers were being incorrectly identified as LC numbers.