### PR TITLE
Custom shelf keys for LC call numbers

### DIFF
--- a/lib/psulib_traject/shelf_key.rb
+++ b/lib/psulib_traject/shelf_key.rb
@@ -5,6 +5,9 @@ module PsulibTraject
     FORWARD_CHARS = ('0'..'9').to_a + ('A'..'Z').to_a
     CHAR_MAP = FORWARD_CHARS.zip(FORWARD_CHARS.reverse).to_h
 
+    # Map lower-case letters to numbers for cutter sorting
+    LOWER_MAP = ('a'..'z').to_a.zip(('00'..'26').to_a).to_h
+
     class NullKey < NullObject; end
 
     attr_reader :call_number
@@ -17,7 +20,7 @@ module PsulibTraject
 
     # @return [String]
     def forward
-      Lcsort.normalize(call_number) || NullKey.new
+      Lcsort.normalize(call_number) || normalize
     end
 
     # @return [String]
@@ -28,5 +31,27 @@ module PsulibTraject
         .append('~')
         .join
     end
+
+    private
+
+      def normalize
+        Lcsort.normalize(cleaned) || NullKey.new
+      end
+
+      # @note If Lcsort can't properly normalize the call number, we "clean" it up by translating unsortable characters
+      # into sortable ones:
+      #
+      # 1. Lower-case letters are translated into numbers 00 through 25. Ex. PZ7.H56774Fz becomes PZ7.H56774F25
+      # 2. Colons are replaced with periods
+      # 3. LC numbers that have no number after their letter classification have a '0' added. Ex, KKP.B634 becomes
+      #    KKP0.B634
+      #
+      # Note that this only affects the _key_. The original call number is unchanged.
+      def cleaned
+        call_number
+          .gsub(/([a-z])/, LOWER_MAP)
+          .gsub(/:/, '.')
+          .gsub(/(^[A-Z]{1,3})\.([A-Z])/, '\10.\2')
+      end
   end
 end

--- a/spec/lib/psulib_traject/shelf_key_spec.rb
+++ b/spec/lib/psulib_traject/shelf_key_spec.rb
@@ -13,7 +13,35 @@ RSpec.describe PsulibTraject::ShelfKey do
   context 'with a number that Lcsort cannot process' do
     let(:call_number) { 'Fiction G758thefu 2015' }
 
-    its(:forward) { is_expected.to be_nil }
-    its(:reverse) { is_expected.to be_nil }
+    its(:forward) { is_expected.to be_a(PsulibTraject::ShelfKey::NullKey) }
+    its(:reverse) { is_expected.to be_a(PsulibTraject::ShelfKey::NullKey) }
+  end
+
+  context 'with lower-case letters in the middle of a cutter' do
+    let(:call_number) { 'LD4481.P8kG45 2008' }
+
+    its(:forward) { is_expected.to eq('LD.4481.P810.G45--2008') }
+    its(:reverse) { is_expected.to eq('EM.VVRY.ARYZ.JVU--XZZR~') }
+  end
+
+  context 'with lower-case letters at the end of a cutter' do
+    let(:call_number) { 'PZ7.H56774Fou 2014' }
+
+    its(:forward) { is_expected.to eq('PZ.0007.H56774.F1420--2014') }
+    its(:reverse) { is_expected.to eq('A0.ZZZS.IUTSSV.KYVXZ--XZYV~') }
+  end
+
+  context 'with colons in a cutter' do
+    let(:call_number) { 'G3824.S8:2P4E635 2017 .P4' }
+
+    its(:forward) { is_expected.to eq('G..3824.S8.0002.P4.E635--2017P0004') }
+    its(:reverse) { is_expected.to eq('J..WRXV.7R.ZZZX.AV.LTWU--XZYSAZZZV~') }
+  end
+
+  context 'with three-letter LC classifications' do
+    let(:call_number) { 'KJD.In8i' }
+
+    its(:forward) { is_expected.to eq('KJD0000.I13808') }
+    its(:reverse) { is_expected.to eq('FGMZZZZ.HYWRZR~') }
   end
 end


### PR DESCRIPTION
When Lcsort is not able to create a shelf key, we manipulate the call number into something that it can sort. Lower case characters are converted to numbers, colons are removed, and a zero is added to the LC classification if no number is present.

## Details

### Lower-Case Cutters

If a call number has lower-case values in the cutter, ex. `PZ7.H56774Fou 2014` the key will look like `PZ.0007.H56774.F1420--2014` where the "ou" has been translated into "1420". This way, the key should still sort. Cases like `LD4481.P8kG45` produce a key that looks like `LD.4481.P810.G45--2008`, where the "k" is replaced with "10".

### LC Classifications with no digits

If the LC classification part of the call number has no digits, ex. `KKP.B634b`, we add a zero. This assumes that "KKP" would sort _before_ "KKP1" or "KKQ". So the preceding example has a key that looks like `KKP0000.B63401`, with padded zeros and the "b" in the cutter translated to "01".