### PR TITLE
Add subject_browse_facet

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,3 +35,7 @@ Lint/MissingSuper:
 Lint/MixedRegexpCaptureTypes:
   Exclude:
     - 'lib/psulib_traject/processors/call_number/lc.rb'
+
+RSpec/ImplicitSubject:
+  Exclude:
+    - 'spec/lib/psulib_traject/macros/subjects_spec.rb'

--- a/config/traject.rb
+++ b/config/traject.rb
@@ -11,6 +11,7 @@ require 'psulib_traject'
 extend Traject::Macros::Marc21
 extend Traject::Macros::Marc21Semantics
 extend PsulibTraject::Macros
+extend PsulibTraject::Macros::Subjects
 
 settings do
   provide 'solr.url', PsulibTraject::SolrManager.new.query_url.to_s

--- a/config/traject.rb
+++ b/config/traject.rb
@@ -253,6 +253,12 @@ to_field 'subject_facet', process_subject_hierarchy(hierarchy_fields)
 ## Subject facet (sidebar)
 to_field 'subject_topic_facet', process_subject_topic_facet('650|*0|aa:650|*0|x:650|*1|aa:650|*1|x:651|*0|a:651|*0|x:600abcdtq:610abt:610x:611abt:611x')
 
+## Subject browse facet
+to_field 'subject_browse_facet', process_subject_browse_facet(
+  standard_fields: '650|*0|abcdgvxyz:650|*1|abcdgvxyz:650|*3|abcdgvxyz:650|*3|abcdgvxyz',
+  pst_fields: '650|*7|abcdgvxyz'
+)
+
 # Genre Fields
 #
 ## Main genre

--- a/lib/psulib_traject.rb
+++ b/lib/psulib_traject.rb
@@ -17,6 +17,7 @@ module PsulibTraject
   require 'psulib_traject/hathi_overlap_reducer'
   require 'psulib_traject/holdings'
   require 'psulib_traject/macros'
+  require 'psulib_traject/macros/subjects'
   require 'psulib_traject/marc_combining_reader'
   require 'psulib_traject/null_object'
   require 'psulib_traject/processors/access_facet'

--- a/lib/psulib_traject/macros.rb
+++ b/lib/psulib_traject/macros.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-SEPARATOR = '—'
 NOT_FULLTEXT = /addendum|appendices|appendix|appendixes|cover|excerpt|executive summary|index/i.freeze
 ESTIMATE_TOLERANCE = 15
 MIN_YEAR = 500
@@ -8,60 +7,6 @@ MAX_YEAR = Time.new.year + 6
 
 module PsulibTraject
   module Macros
-    # A set of custom traject macros (extractors and normalizers)
-    # For the hierarchical subject display
-    #
-    # Split with em dash along v,x,y,z
-    def process_subject_hierarchy(fields)
-      lambda do |record, accumulator|
-        return nil unless record.is_a? MARC::Record
-
-        subjects = []
-        split_on_subfield = %w[v x y z]
-        Traject::MarcExtractor.cached(fields).collect_matching_lines(record) do |field, spec, extractor|
-          subject = extractor.collect_subfields(field, spec).first
-          unless subject.nil?
-            field.subfields.each do |s_field|
-              subject = add_subject_separator(subject, s_field) if split_on_subfield.include?(s_field.code)
-            end
-            subject = subject.split(SEPARATOR)
-            subject = subject.map { |s| Traject::Macros::Marc21.trim_punctuation(s) }.join(SEPARATOR)
-            subjects << subject # if include_subject
-          end
-        end
-
-        accumulator.replace(subjects.compact.uniq)
-      end
-    end
-
-    # For the split subject facet
-    #
-    # Split with em dash along v,x,y,z
-    def process_subject_topic_facet(fields)
-      lambda do |record, accumulator|
-        return nil unless record.is_a? MARC::Record
-
-        subjects = []
-        split_on_subfield = %w[v x y z]
-        Traject::MarcExtractor.cached(fields).collect_matching_lines(record) do |field, spec, extractor|
-          subject = extractor.collect_subfields(field, spec).first
-          unless subject.nil?
-            field.subfields.each do |s_field|
-              subject = add_subject_separator(subject, s_field) if split_on_subfield.include?(s_field.code)
-            end
-            subject = subject.split(SEPARATOR)
-            subjects << subject.map { |s| Traject::Macros::Marc21.trim_punctuation(s) }
-          end
-        end
-
-        accumulator.replace(subjects.flatten.compact.uniq)
-      end
-    end
-
-    def add_subject_separator(subject, s_field)
-      subject.gsub(" #{s_field.value}", "#{SEPARATOR}#{s_field.value}")
-    end
-
     # For genre facet and display
     #
     # limit to subfield $2 vocabularies for 655|*7 genres

--- a/lib/psulib_traject/macros/subjects.rb
+++ b/lib/psulib_traject/macros/subjects.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module PsulibTraject::Macros::Subjects
+  SEPARATOR = '—'
+
+  # A set of custom traject macros (extractors and normalizers)
+  # For the hierarchical subject display
+  #
+  # Split with em dash along v,x,y,z
+  def process_subject_hierarchy(fields)
+    lambda do |record, accumulator|
+      return nil unless record.is_a? MARC::Record
+
+      subjects = []
+      split_on_subfield = %w[v x y z]
+      Traject::MarcExtractor.cached(fields).collect_matching_lines(record) do |field, spec, extractor|
+        subject = extractor.collect_subfields(field, spec).first
+        unless subject.nil?
+          field.subfields.each do |s_field|
+            subject = add_subject_separator(subject, s_field) if split_on_subfield.include?(s_field.code)
+          end
+          subject = subject.split(SEPARATOR)
+          subject = subject.map { |s| Traject::Macros::Marc21.trim_punctuation(s) }.join(SEPARATOR)
+          subjects << subject # if include_subject
+        end
+      end
+
+      accumulator.replace(subjects.compact.uniq)
+    end
+  end
+
+  # For the split subject facet
+  #
+  # Split with em dash along v,x,y,z
+  def process_subject_topic_facet(fields)
+    lambda do |record, accumulator|
+      return nil unless record.is_a? MARC::Record
+
+      subjects = []
+      split_on_subfield = %w[v x y z]
+      Traject::MarcExtractor.cached(fields).collect_matching_lines(record) do |field, spec, extractor|
+        subject = extractor.collect_subfields(field, spec).first
+        unless subject.nil?
+          field.subfields.each do |s_field|
+            subject = add_subject_separator(subject, s_field) if split_on_subfield.include?(s_field.code)
+          end
+          subject = subject.split(SEPARATOR)
+          subjects << subject.map { |s| Traject::Macros::Marc21.trim_punctuation(s) }
+        end
+      end
+
+      accumulator.replace(subjects.flatten.compact.uniq)
+    end
+  end
+
+  def add_subject_separator(subject, s_field)
+    subject.gsub(" #{s_field.value}", "#{SEPARATOR}#{s_field.value}")
+  end
+end

--- a/spec/lib/psulib_traject/macros/subjects_spec.rb
+++ b/spec/lib/psulib_traject/macros/subjects_spec.rb
@@ -4,30 +4,7 @@ RSpec.describe PsulibTraject::Macros::Subjects do
   let(:result) { indexer.map_record(record) }
 
   describe 'process_subject_hierarchy' do
-    let(:record) do
-      MarcBot.build(
-        :record,
-        f610: {
-          indicator2: '5',
-          a: 'Include'
-        },
-        f600: {
-          indicator2: '0',
-          a: 'John.',
-          t: 'Title.',
-          v: 'split genre',
-          d: '2015',
-          2 => 'special'
-        },
-        f630: {
-          indicator2: '0',
-          x: 'Fiction',
-          y: '1492',
-          z: "don't ignore",
-          t: 'TITLE.'
-        }
-      )
-    end
+    let(:record) { MarcBot.build(:subject_facet) }
 
     it 'only separates v,x,y,z with em dash, strips punctuation' do
       expect(result['subject_display_ssm']).to include(
@@ -39,27 +16,29 @@ RSpec.describe PsulibTraject::Macros::Subjects do
   end
 
   describe 'process_subject_topic_facet' do
-    let(:record) do
-      MarcBot.build(
-        :record,
-        f600: {
-          indicator2: '0',
-          a: 'John.',
-          x: 'Join',
-          t: 'Title',
-          d: '2015.'
-        },
-        f650: {
-          indicator2: '0',
-          x: 'Fiction',
-          y: '1492',
-          v: 'split genre'
-        }
-      )
-    end
+    let(:record) { MarcBot.build(:subject_topic_facet) }
 
     it 'includes subjects split along v, x, y and z, strips punctuation' do
       expect(result['subject_topic_facet']).to include('John. Title 2015', 'Fiction')
+    end
+  end
+
+  describe '#process_subject_browse_facet' do
+    subject { result['subject_browse_facet'] }
+
+    context "when 'pst' is not in subfield 2" do
+      let(:record) { MarcBot.build(:non_pst_subjects) }
+
+      it { is_expected.to contain_exactly(['A', 'B', 'C'].join(described_class::SEPARATOR)) }
+    end
+
+    context "when 'pst' is in subfield 2" do
+      let(:record) { MarcBot.build(:pst_subjects) }
+
+      it { is_expected.to contain_exactly(
+        ['A', 'B', 'C'].join(described_class::SEPARATOR),
+        ['L', 'M', 'N'].join(described_class::SEPARATOR)
+      )}
     end
   end
 end

--- a/spec/lib/psulib_traject/macros/subjects_spec.rb
+++ b/spec/lib/psulib_traject/macros/subjects_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Subjects' do
+RSpec.describe PsulibTraject::Macros::Subjects do
   describe 'process_subject_hierarchy' do
     before(:all) do
       @subject610 = { '610' => { 'ind1' => '', 'ind2' => '5', 'subfields' => [{ 'a' => 'Include' }] } }
@@ -12,8 +12,8 @@ RSpec.describe 'Subjects' do
     it 'only separates v,x,y,z with em dash, strips punctuation' do
       result = indexer.map_record(@sample_marc)
       expect(result['subject_display_ssm']).to include('Include')
-      expect(result['subject_display_ssm']).to include("John. Title#{SEPARATOR}split genre 2015")
-      expect(result['subject_display_ssm']).to include("Fiction#{SEPARATOR}1492#{SEPARATOR}don't ignore TITLE")
+      expect(result['subject_display_ssm']).to include("John. Title#{described_class::SEPARATOR}split genre 2015")
+      expect(result['subject_display_ssm']).to include("Fiction#{described_class::SEPARATOR}1492#{described_class::SEPARATOR}don't ignore TITLE")
     end
   end
 

--- a/spec/lib/psulib_traject/macros/subjects_spec.rb
+++ b/spec/lib/psulib_traject/macros/subjects_spec.rb
@@ -1,33 +1,65 @@
 # frozen_string_literal: true
 
 RSpec.describe PsulibTraject::Macros::Subjects do
+  let(:result) { indexer.map_record(record) }
+
   describe 'process_subject_hierarchy' do
-    before(:all) do
-      @subject610 = { '610' => { 'ind1' => '', 'ind2' => '5', 'subfields' => [{ 'a' => 'Include' }] } }
-      @subject600 = { '600' => { 'ind1' => '', 'ind2' => '0', 'subfields' => [{ 'a' => 'John.' }, { 't' => 'Title.' }, { 'v' => 'split genre' }, { 'd' => '2015' }, { '2' => 'special' }] } }
-      @subject630 = { '630' => { 'ind1' => '', 'ind2' => '0', 'subfields' => [{ 'x' => 'Fiction' }, { 'y' => '1492' }, { 'z' => "don't ignore" }, { 't' => 'TITLE.' }] } }
-      @sample_marc = MARC::Record.new_from_hash('fields' => [@subject610, @subject600, @subject630], 'leader' => '1234567890')
+    let(:record) do
+      MarcBot.build(
+        :record,
+        f610: {
+          indicator2: '5',
+          a: 'Include'
+        },
+        f600: {
+          indicator2: '0',
+          a: 'John.',
+          t: 'Title.',
+          v: 'split genre',
+          d: '2015',
+          2 => 'special'
+        },
+        f630: {
+          indicator2: '0',
+          x: 'Fiction',
+          y: '1492',
+          z: "don't ignore",
+          t: 'TITLE.'
+        }
+      )
     end
 
     it 'only separates v,x,y,z with em dash, strips punctuation' do
-      result = indexer.map_record(@sample_marc)
-      expect(result['subject_display_ssm']).to include('Include')
-      expect(result['subject_display_ssm']).to include("John. Title#{described_class::SEPARATOR}split genre 2015")
-      expect(result['subject_display_ssm']).to include("Fiction#{described_class::SEPARATOR}1492#{described_class::SEPARATOR}don't ignore TITLE")
+      expect(result['subject_display_ssm']).to include(
+        'Include',
+        "John. Title#{described_class::SEPARATOR}split genre 2015",
+        "Fiction#{described_class::SEPARATOR}1492#{described_class::SEPARATOR}don't ignore TITLE"
+      )
     end
   end
 
   describe 'process_subject_topic_facet' do
-    before(:all) do
-      @subject600 = { '600' => { 'ind1' => '', 'ind2' => '0', 'subfields' => [{ 'a' => 'John.' }, { 'x' => 'Join' }, { 't' => 'Title' }, { 'd' => '2015.' }] } }
-      @subject650 = { '650' => { 'ind1' => '', 'ind2' => '0', 'subfields' => [{ 'x' => 'Fiction' }, { 'y' => '1492' }, { 'v' => 'split genre' }] } }
-      @sample_marc = MARC::Record.new_from_hash('fields' => [@subject600, @subject650], 'leader' => '1234567890')
+    let(:record) do
+      MarcBot.build(
+        :record,
+        f600: {
+          indicator2: '0',
+          a: 'John.',
+          x: 'Join',
+          t: 'Title',
+          d: '2015.'
+        },
+        f650: {
+          indicator2: '0',
+          x: 'Fiction',
+          y: '1492',
+          v: 'split genre'
+        }
+      )
     end
 
     it 'includes subjects split along v, x, y and z, strips punctuation' do
-      result = indexer.map_record(@sample_marc)
-      expect(result['subject_topic_facet']).to include('John. Title 2015')
-      expect(result['subject_topic_facet']).to include('Fiction')
+      expect(result['subject_topic_facet']).to include('John. Title 2015', 'Fiction')
     end
   end
 end

--- a/spec/records/subjects.rb
+++ b/spec/records/subjects.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+MarcBot.define do
+  factory :subject_facet do
+    f610 do
+      { indicator2: '5', a: 'Include' }
+    end
+
+    f600 do
+      { indicator2: '0', a: 'John.', t: 'Title.', v: 'split genre', d: '2015', 2 => 'special' }
+    end
+
+    f630 do
+      { indicator2: '0', x: 'Fiction', y: '1492', z: "don't ignore", t: 'TITLE.' }
+    end
+  end
+
+  factory :subject_topic_facet do
+    f600 do
+      { indicator2: '0', a: 'John.', x: 'Join', t: 'Title', d: '2015.' }
+    end
+
+    f650 do
+      { indicator2: '0', x: 'Fiction', y: '1492', v: 'split genre' }
+    end
+  end
+
+  factory :non_pst_subjects do
+    f650 do
+      { indicator2: '0', x: 'A', y: 'B', z: 'C', t: 'ignore' }
+    end
+
+    f650 do
+      { indicator2: '7', x: 'L', y: 'M', z: 'N' }
+    end
+  end
+
+  factory :pst_subjects do
+    f650 do
+      { indicator2: '0', x: 'A', y: 'B', z: 'C', t: 'ignore' }
+    end
+
+    f650 do
+      { indicator2: '7', x: 'L', y: 'M', z: 'N', 2 => 'Pst' }
+    end
+  end
+end


### PR DESCRIPTION
Addresses #329 

Creates a new `subject_browse_facet` field to support browsing subjects. Includes a refactoring of our existing macros, which splits out the subject-related macros into their own file, then refactors the tests and macro code separately.