### PR TITLE
fix for subjects when record with 650 has an indicator but no subfields

### DIFF
--- a/lib/psulib_traject/macros/subjects.rb
+++ b/lib/psulib_traject/macros/subjects.rb
@@ -14,7 +14,10 @@ module PsulibTraject::Macros::Subjects
 
       subjects = []
       Traject::MarcExtractor.cached(fields).collect_matching_lines(record) do |field, spec, extractor|
-        subjects << extract_subjects(field, spec, extractor).join(SEPARATOR)
+        extracted_subjects = extract_subjects(field, spec, extractor)
+        unless extracted_subjects.empty?
+          subjects << extracted_subjects.join(SEPARATOR)
+        end
       end
       accumulator.replace(subjects.compact.uniq)
     end
@@ -26,12 +29,18 @@ module PsulibTraject::Macros::Subjects
 
       subjects = []
       Traject::MarcExtractor.cached(standard_fields).collect_matching_lines(record) do |field, spec, extractor|
-        subjects << extract_subjects(field, spec, extractor).join(SEPARATOR)
+        extracted_subjects = extract_subjects(field, spec, extractor)
+        unless extracted_subjects.empty?
+          subjects << extract_subjects(field, spec, extractor).join(SEPARATOR)
+        end
       end
 
       Traject::MarcExtractor.cached(pst_fields).collect_matching_lines(record) do |field, spec, extractor|
         if field.indicator2 == '7' && (field['2'] || '').match?(/pst/i)
-          subjects << extract_subjects(field, spec, extractor).join(SEPARATOR)
+          extracted_subjects = extract_subjects(field, spec, extractor)
+          unless extracted_subjects.empty?
+            subjects << extracted_subjects.join(SEPARATOR)
+          end
         end
       end
 
@@ -57,7 +66,7 @@ module PsulibTraject::Macros::Subjects
 
   def extract_subjects(field, spec, extractor)
     subject = extractor.collect_subfields(field, spec).first
-    return if subject.nil?
+    return [] if subject.nil?
 
     field.subfields.each do |subfield|
       if SUBFIELD_SPLIT.include?(subfield.code)

--- a/spec/lib/psulib_traject/macros/subjects_spec.rb
+++ b/spec/lib/psulib_traject/macros/subjects_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe PsulibTraject::Macros::Subjects do
         "Fiction#{described_class::SEPARATOR}1492#{described_class::SEPARATOR}don't ignore TITLE"
       )
     end
+
+    context 'when empty 650 only' do
+      let(:record) { MarcBot.build(:subject_empty_650) }
+
+      it 'handles empty 650s correctly' do
+        expect(result['subject_display_ssm']).to be_nil
+      end
+    end
   end
 
   describe 'process_subject_topic_facet' do
@@ -39,6 +47,14 @@ RSpec.describe PsulibTraject::Macros::Subjects do
         ['A', 'B', 'C'].join(described_class::SEPARATOR),
         ['L', 'M', 'N'].join(described_class::SEPARATOR)
       )}
+    end
+
+    context 'when empty 650 only' do
+      let(:record) { MarcBot.build(:subject_empty_650) }
+
+      it 'handles empty 650s correctly' do
+        expect(result['subject_browse_facet']).to be_nil
+      end
     end
   end
 end

--- a/spec/records/subjects.rb
+++ b/spec/records/subjects.rb
@@ -15,6 +15,12 @@ MarcBot.define do
     end
   end
 
+  factory :subject_empty_650 do
+    f650 do
+      { indicator2: '0' }
+    end
+  end
+
   factory :subject_topic_facet do
     f600 do
       { indicator2: '0', a: 'John.', x: 'Join', t: 'Title', d: '2015.' }


### PR DESCRIPTION
mapping was failing for records with weird 650s

eg. https://catalog.libraries.psu.edu/catalog/14651589/marc_view

![Screen Shot 2021-09-01 at 1 53 56 PM](https://user-images.githubusercontent.com/6477867/131724122-f4078c6e-809c-4f41-b8a7-181a366f6288.png)
