### PR TITLE
Clean up spec_helper

### DIFF
--- a/spec/integration/access_facet_spec.rb
+++ b/spec/integration/access_facet_spec.rb
@@ -2,8 +2,6 @@
 
 RSpec.describe 'Access facet' do
   describe 'access_facet' do
-    let(:fixture_path) { './spec/fixtures' }
-
     it 'works with empty record, returns empty' do
       @empty_record = MARC::Record.new
       @empty_record.append(MARC::ControlField.new('001', '000000000'))

--- a/spec/integration/config_spec.rb
+++ b/spec/integration/config_spec.rb
@@ -4,7 +4,6 @@ RSpec::Matchers.define_negated_matcher :not_include, :include
 
 RSpec.describe 'Config' do
   let(:leader) { '1234567890' }
-  let(:fixture_path) { './spec/fixtures' }
 
   describe 'id' do
     context 'one record with trailing whitespace' do

--- a/spec/lib/psulib_traject/marc_combining_reader_spec.rb
+++ b/spec/lib/psulib_traject/marc_combining_reader_spec.rb
@@ -3,7 +3,6 @@
 RSpec.describe PsulibTraject::MarcCombiningReader do
   subject(:reader) { described_class.new(File.open(File.join(fixture_path, 'split_items_test.mrc').to_s, 'r'), 'marc_source.type' => 'binary') }
 
-  let(:fixture_path) { './spec/fixtures' }
   let(:results) { reader.each.to_a }
 
   describe '#each' do

--- a/spec/lib/psulib_traject/processors/pub_date_spec.rb
+++ b/spec/lib/psulib_traject/processors/pub_date_spec.rb
@@ -2,8 +2,6 @@
 
 RSpec.describe PsulibTraject::Processors::PubDate do
   describe 'process_publication_date' do
-    let(:fixture_path) { './spec/fixtures' }
-
     it "works when there's no date information" do
       @empty_record = MARC::Record.new
       @empty_record.append(MARC::ControlField.new('001', '000000000'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -34,17 +34,7 @@ Dir[Pathname.pwd.join('spec', 'support', '**', '*.rb')].sort.each { |f| require 
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 
-def indexer
-  @indexer
-end
-
 RSpec.configure do |config|
-  config.before(:all) do
-    @indexer ||= Traject::Indexer.new.tap do |indexer|
-      indexer.load_config_file('./config/traject.rb')
-    end
-  end
-
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Helpers
+  def fixture_path
+    Pathname.pwd.join('spec/fixtures')
+  end
+
+  def indexer
+    @indexer
+  end
+end
+
+RSpec.configure do |config|
+  config.before(:all) do
+    @indexer ||= Traject::Indexer.new.tap do |indexer|
+      indexer.load_config_file('./config/traject.rb')
+    end
+  end
+
+  config.include Helpers
+end


### PR DESCRIPTION
Extracts out our helpers into their own file to keep the spec_helper file a little leaner.

Note: this was some refactoring that was part of another PR that we ended up not needing, so I'm just putting it here so we don't waste it.