### PR TITLE
Adds trim_punctuation to subject_other_display field

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,7 @@ PLATFORMS
   universal-java-10
   universal-java-11
   universal-java-14
+  universal-java-15
   x86_64-darwin-20
   x86_64-linux
 

--- a/config/traject.rb
+++ b/config/traject.rb
@@ -243,6 +243,9 @@ to_field 'language_facet', marc_languages('008[35-37]')
 ## Primary subject
 to_field 'subject_tsim', extract_marc('600abcdfklmnopqrtvxyz:610abfklmnoprstvxyz:611abcdefgklnpqstvxyz:630adfgklmnoprstvxyz:647acdg:648a:650abcd:651a:653a:654ab')
 
+## Other Subject
+to_field 'subject_other_display_ssm', extract_marc('653a')
+
 ## Additional subject fields
 to_field 'subject_addl_tsim', extract_marc('600vxyz:610vxyz:611vxyz:630vxyz:647vxyz:648vxyz:650vxyz:651vxyz:654vyz')
 

--- a/config/traject.rb
+++ b/config/traject.rb
@@ -244,7 +244,7 @@ to_field 'language_facet', marc_languages('008[35-37]')
 to_field 'subject_tsim', extract_marc('600abcdfklmnopqrtvxyz:610abfklmnoprstvxyz:611abcdefgklnpqstvxyz:630adfgklmnoprstvxyz:647acdg:648a:650abcd:651a:653a:654ab')
 
 ## Other Subject
-to_field 'subject_other_display_ssm', extract_marc('653a')
+to_field 'subject_other_display_ssm', extract_marc('653a'), trim_punctuation
 
 ## Additional subject fields
 to_field 'subject_addl_tsim', extract_marc('600vxyz:610vxyz:611vxyz:630vxyz:647vxyz:648vxyz:650vxyz:651vxyz:654vyz')

--- a/config/traject.rb
+++ b/config/traject.rb
@@ -246,7 +246,6 @@ to_field 'subject_tsim', extract_marc('600abcdfklmnopqrtvxyz:610abfklmnoprstvxyz
 ## Other Subject
 to_field 'subject_other_display_ssm', extract_marc('653a'), trim_punctuation
 
-
 ## Additional subject fields
 to_field 'subject_addl_tsim', extract_marc('600vxyz:610vxyz:611vxyz:630vxyz:647vxyz:648vxyz:650vxyz:651vxyz:654vyz')
 


### PR DESCRIPTION
There were periods at the end of the subjects and I don't think we want them displaying that way in the Cat.  I found this 'trim_punctuation' parameter that seems to fix it.  I'm not sure where 'trim_punctuation' is defined though.