### PR TITLE
Extract deprecated oclcs

### DIFF
--- a/config/traject.rb
+++ b/config/traject.rb
@@ -81,6 +81,9 @@ to_field 'issn_ssm', extract_marc('022a', separator: nil)
 ## Not sure why didn't end up using the method Traject::Macros::Marc21Semantics::oclcnum
 to_field 'oclc_number_ssim', extract_oclc_number
 
+# Deprecated OCLCs
+to_field 'deprecated_oclcs_tsim', extract_deprecated_oclcs
+
 # Library of Congress number
 to_field 'lccn_ssim', extract_marc('010a'), trim_punctuation
 

--- a/lib/psulib_traject.rb
+++ b/lib/psulib_traject.rb
@@ -33,6 +33,7 @@ module PsulibTraject
   require 'psulib_traject/processors/record_type'
   require 'psulib_traject/processors/summary_holdings'
   require 'psulib_traject/processors/title_display'
+  require 'psulib_traject/processors/oclc_extract'
   require 'psulib_traject/shelf_key'
   require 'psulib_traject/solr_manager'
   require 'psulib_traject/subject_heading'
@@ -52,6 +53,11 @@ module PsulibTraject
     # work-around for https://github.com/jruby/jruby/issues/4868
     def regex_to_extract_data_from_a_string(str, regex)
       str[regex]
+    end
+
+    # work-around for https://github.com/jruby/jruby/issues/4868
+    def regex_split(str, regex)
+      str.split(regex).to_a
     end
   end
 end

--- a/lib/psulib_traject/macros.rb
+++ b/lib/psulib_traject/macros.rb
@@ -168,18 +168,6 @@ module PsulibTraject
       end
     end
 
-    def includes_oclc_indicators?(sf_a)
-      sf_a.include?('OCoLC') ||
-        sf_a.include?('ocn') ||
-        sf_a.include?('ocm') ||
-        sf_a.include?('OCLC')
-    end
-
-    # work-around for https://github.com/jruby/jruby/issues/4868
-    def regex_split(str, regex)
-      str.split(regex).to_a
-    end
-
     def exclude_locations
       lambda do |_record, accumulator|
         accumulator.reject! { |value| ConfigSettings.location_excludes.include?(value) }
@@ -194,7 +182,53 @@ module PsulibTraject
       end
     end
 
+    # Extract deprecated OCLCs
+    def extract_deprecated_oclcs
+      lambda do |record, accumulator|
+        record.fields(%w(035 019)).each do |field|
+          case field.tag
+          when '019'
+            get_019_deprecated_oclcs(field, accumulator)
+          when '035'
+            get_035_deprecated_oclcs(field, accumulator)
+          end
+        end
+        accumulator.uniq!
+      end
+    end
+
     private
+
+      def get_019_deprecated_oclcs(field, accumulator)
+        field.subfields.each do |subfield|
+          if subfield.code == 'a' && !subfield.value.nil? &&
+              !subfield.value.empty? && subfield.value.match(/^[0-9]{3,15}$/)
+            accumulator << subfield.value
+          end
+        end
+      end
+
+      def get_035_deprecated_oclcs(field, accumulator)
+        field.subfields.each do |subfield|
+          if subfield.code == 'z' && !subfield.value.nil? &&
+              !subfield.value.empty? && includes_oclc_indicators?(subfield.value)
+            subfield_cleaned = regex_split(subfield.value, //).map { |x| x[/\d+/] }.compact.join('')
+            accumulator << subfield_cleaned
+          end
+        end
+      end
+
+      def includes_oclc_indicators?(sf_a)
+        sf_a.include?('OCoLC') ||
+          sf_a.include?('ocn') ||
+          sf_a.include?('ocm') ||
+          sf_a.include?('OCLC')
+      end
+
+      # work-around for https://github.com/jruby/jruby/issues/4868
+      def regex_split(str, regex)
+        str.split(regex).to_a
+      end
 
       def psu_thesis?(record)
         record.fields('949').each do |field|

--- a/lib/psulib_traject/processors/oclc_extract.rb
+++ b/lib/psulib_traject/processors/oclc_extract.rb
@@ -32,11 +32,13 @@ module PsulibTraject
       private
 
         def get_035_primary_oclc(field, accumulator)
-          unless field&.[]('a').nil?
-            if includes_oclc_indicators?(field['a'])
-              subfield = PsulibTraject.regex_split(field['a'], //).map { |x| x[/\d+/] }.compact.join('')
+          field.subfields.each do |subfield|
+            if !subfield.value.nil? && !subfield.value.empty?
+              subfield.code == 'a' && includes_oclc_indicators?(subfield.value)
+              subfield = PsulibTraject.regex_split(subfield.value, //).map { |x| x[/\d+/] }.compact.join('')
+              accumulator << subfield
+              break
             end
-            accumulator << subfield
           end
         end
 

--- a/lib/psulib_traject/processors/oclc_extract.rb
+++ b/lib/psulib_traject/processors/oclc_extract.rb
@@ -24,17 +24,21 @@ module PsulibTraject
 
       def extract_primary_oclc
         record.fields(['035']).each do |field|
+          get_035_primary_oclc(field, accumulator)
+          accumulator.uniq!
+        end
+      end
+
+      private
+
+        def get_035_primary_oclc(field, accumulator)
           unless field&.[]('a').nil?
             if includes_oclc_indicators?(field['a'])
               subfield = PsulibTraject.regex_split(field['a'], //).map { |x| x[/\d+/] }.compact.join('')
             end
             accumulator << subfield
           end
-          accumulator.uniq!
         end
-      end
-
-      private
 
         def get_019_deprecated_oclcs(field, accumulator)
           field.subfields.each do |subfield|
@@ -57,9 +61,9 @@ module PsulibTraject
 
         def includes_oclc_indicators?(sf_a)
           sf_a.include?('OCoLC') ||
-              sf_a.include?('ocn') ||
-              sf_a.include?('ocm') ||
-              sf_a.include?('OCLC')
+            sf_a.include?('ocn') ||
+            sf_a.include?('ocm') ||
+            sf_a.include?('OCLC')
         end
     end
   end

--- a/lib/psulib_traject/processors/oclc_extract.rb
+++ b/lib/psulib_traject/processors/oclc_extract.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module PsulibTraject
+  module Processors
+    class OclcExtract
+      attr_accessor :record, :accumulator
+
+      def initialize(record, accumulator)
+        @record = record
+        @accumulator = accumulator
+      end
+
+      def extract_deprecated_oclcs
+        record.fields(%w(035 019)).each do |field|
+          case field.tag
+          when '019'
+            get_019_deprecated_oclcs(field, accumulator)
+          when '035'
+            get_035_deprecated_oclcs(field, accumulator)
+          end
+        end
+        accumulator.uniq!
+      end
+
+      def extract_primary_oclc
+        record.fields(['035']).each do |field|
+          unless field&.[]('a').nil?
+            if includes_oclc_indicators?(field['a'])
+              subfield = PsulibTraject.regex_split(field['a'], //).map { |x| x[/\d+/] }.compact.join('')
+            end
+            accumulator << subfield
+          end
+          accumulator.uniq!
+        end
+      end
+
+      private
+
+        def get_019_deprecated_oclcs(field, accumulator)
+          field.subfields.each do |subfield|
+            if subfield.code == 'a' && !subfield.value.nil? &&
+                !subfield.value.empty? && subfield.value.match(/^[0-9]{3,15}$/)
+              accumulator << subfield.value
+            end
+          end
+        end
+
+        def get_035_deprecated_oclcs(field, accumulator)
+          field.subfields.each do |subfield|
+            if subfield.code == 'z' && !subfield.value.nil? &&
+                !subfield.value.empty? && includes_oclc_indicators?(subfield.value)
+              subfield_cleaned = PsulibTraject.regex_split(subfield.value, //).map { |x| x[/\d+/] }.compact.join('')
+              accumulator << subfield_cleaned
+            end
+          end
+        end
+
+        def includes_oclc_indicators?(sf_a)
+          sf_a.include?('OCoLC') ||
+              sf_a.include?('ocn') ||
+              sf_a.include?('ocm') ||
+              sf_a.include?('OCLC')
+        end
+    end
+  end
+end

--- a/lib/psulib_traject/processors/oclc_extract.rb
+++ b/lib/psulib_traject/processors/oclc_extract.rb
@@ -32,13 +32,11 @@ module PsulibTraject
       private
 
         def get_035_primary_oclc(field, accumulator)
-          field.subfields.each do |subfield|
-            if !subfield.value.nil? && !subfield.value.empty?
-              subfield.code == 'a' && includes_oclc_indicators?(subfield.value)
-              subfield = PsulibTraject.regex_split(subfield.value, //).map { |x| x[/\d+/] }.compact.join('')
-              accumulator << subfield
-              break
+          unless field&.[]('a').nil?
+            if includes_oclc_indicators?(field['a'])
+              subfield = PsulibTraject.regex_split(field['a'], //).map { |x| x[/\d+/] }.compact.join('')
             end
+            accumulator << subfield
           end
         end
 

--- a/spec/lib/psulib_traject/macros_spec.rb
+++ b/spec/lib/psulib_traject/macros_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+RSpec.describe PsulibTraject::Macros do
+  before do
+    extend described_class
+  end
+
+  describe '#extract_deprecated_oclcs' do
+    let(:record) do
+      object_double('Marc Record',
+                    fields: [
+                      object_double('Marc Field', {
+                                      tag: '035', subfields: [
+                                        object_double('Marc Subfield', {
+                                                        code: 'z',
+                                                        value: '(OCoLC)12345678'
+                                                      })
+                                      ]
+                                    }),
+                      object_double('Marc Field', {
+                                      tag: '019', subfields: [
+                                        object_double('Marc Subfield', {
+                                                        code: 'a',
+                                                        value: '87654321'
+                                                      }),
+                                        object_double('Marc Subfield', {
+                                                        code: 'a',
+                                                        value: '8765432121351235123515'
+                                                      }),
+                                        object_double('Marc Subfield', {
+                                                        code: 'a',
+                                                        value: 'MARS'
+                                                      })
+                                      ]
+                                    })
+                    ])
+    end
+
+    it 'extracts deprecated oclcs' do
+      accumulator = []
+      extract_deprecated_oclcs.call(record, accumulator)
+      expect(accumulator).to eq ['12345678', '87654321']
+    end
+  end
+end

--- a/spec/lib/psulib_traject/processors/oclc_extract_spec.rb
+++ b/spec/lib/psulib_traject/processors/oclc_extract_spec.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe PsulibTraject::Macros do
-  before do
-    extend described_class
-  end
+RSpec.describe PsulibTraject::Processors::OclcExtract do
+  let(:oclc_extract) { described_class.new(record, accumulator) }
 
   describe '#extract_deprecated_oclcs' do
     let(:record) do
@@ -35,11 +33,37 @@ RSpec.describe PsulibTraject::Macros do
                                     })
                     ])
     end
+    let(:accumulator) { [] }
 
     it 'extracts deprecated oclcs' do
-      accumulator = []
-      extract_deprecated_oclcs.call(record, accumulator)
+      oclc_extract.extract_deprecated_oclcs
       expect(accumulator).to eq ['12345678', '87654321']
+    end
+  end
+
+  describe '#extract_primary_oclcs' do
+    let(:record) do
+      object_double('Marc Record',
+                    fields: [
+                      object_double('Marc Field', {
+                                      tag: '035', subfields: [
+                                        object_double('Marc Subfield', {
+                                                        code: 'a',
+                                                        value: '(OCoLC)56789123'
+                                                      }),
+                                        object_double('Marc Subfield', {
+                                                        code: 'z',
+                                                        value: '(OCoLC)12345678'
+                                                      })
+                                      ]
+                                    })
+                    ])
+    end
+    let(:accumulator) { [] }
+
+    it 'extracts primary oclc' do
+      oclc_extract.extract_primary_oclc
+      expect(accumulator).to eq ['56789123']
     end
   end
 end

--- a/spec/lib/psulib_traject/processors/oclc_extract_spec.rb
+++ b/spec/lib/psulib_traject/processors/oclc_extract_spec.rb
@@ -2,37 +2,42 @@
 
 RSpec.describe PsulibTraject::Processors::OclcExtract do
   let(:oclc_extract) { described_class.new(record, accumulator) }
+  let(:leader) { '1234567890' }
 
   describe '#extract_deprecated_oclcs' do
-    let(:record) do
-      object_double('Marc Record',
-                    fields: [
-                      object_double('Marc Field', {
-                                      tag: '035', subfields: [
-                                        object_double('Marc Subfield', {
-                                                        code: 'z',
-                                                        value: '(OCoLC)12345678'
-                                                      })
-                                      ]
-                                    }),
-                      object_double('Marc Field', {
-                                      tag: '019', subfields: [
-                                        object_double('Marc Subfield', {
-                                                        code: 'a',
-                                                        value: '87654321'
-                                                      }),
-                                        object_double('Marc Subfield', {
-                                                        code: 'a',
-                                                        value: '8765432121351235123515'
-                                                      }),
-                                        object_double('Marc Subfield', {
-                                                        code: 'a',
-                                                        value: 'MARS'
-                                                      })
-                                      ]
-                                    })
-                    ])
+    let(:fields) do
+      [
+        { '035' => {
+          'ind1' => '',
+          'ind2' => '',
+          'subfields' => [
+            { 'z' => '(OCoLC)12345678' }
+          ]
+        } },
+        { '019' => {
+          'ind1' => '',
+          'ind2' => '',
+          'subfields' => [
+            { 'a' => '87654321' }
+          ]
+        } },
+        { '019' => {
+          'ind1' => '',
+          'ind2' => '',
+          'subfields' => [
+            { 'a' => '8765432121351235123515' }
+          ]
+        } },
+        { '019' => {
+          'ind1' => '',
+          'ind2' => '',
+          'subfields' => [
+            { 'a' => 'MARS' }
+          ]
+        } }
+      ]
     end
+    let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
     let(:accumulator) { [] }
 
     it 'extracts deprecated oclcs' do
@@ -42,23 +47,25 @@ RSpec.describe PsulibTraject::Processors::OclcExtract do
   end
 
   describe '#extract_primary_oclcs' do
-    let(:record) do
-      object_double('Marc Record',
-                    fields: [
-                      object_double('Marc Field', {
-                                      tag: '035', subfields: [
-                                        object_double('Marc Subfield', {
-                                                        code: 'a',
-                                                        value: '(OCoLC)56789123'
-                                                      }),
-                                        object_double('Marc Subfield', {
-                                                        code: 'z',
-                                                        value: '(OCoLC)12345678'
-                                                      })
-                                      ]
-                                    })
-                    ])
+    let(:fields) do
+      [
+        { '035' => {
+          'ind1' => '',
+          'ind2' => '',
+          'subfields' => [
+            { 'a' => '(OCoLC)56789123' }
+          ]
+        } },
+        { '035' => {
+          'ind1' => '',
+          'ind2' => '',
+          'subfields' => [
+            { 'z' => '(OCoLC)12345678' }
+          ]
+        } }
+      ]
     end
+    let(:record) { MARC::Record.new_from_hash('fields' => fields, 'leader' => leader) }
     let(:accumulator) { [] }
 
     it 'extracts primary oclc' do


### PR DESCRIPTION
Some of this code could potentially be refactored and abstracted into its own Processor class.  I didn't do this though since there were some shared methods in the Macros module.  I felt this needed a test too. The one I added seems a bit weird and there may be a better way of doing it, but it works.

closes #404 