### PR TITLE
Fix issues with some 856 URLs not being indexed for display

### DIFF
--- a/lib/psulib_traject/macros.rb
+++ b/lib/psulib_traject/macros.rb
@@ -46,6 +46,8 @@ module PsulibTraject
 
         link_data_all.each do |link_data|
           link_data[:url].flatten.compact.each do |link|
+            link = "http://#{link}" if link.start_with?('www.')
+
             url_match = url_match(link)
             next if url_match.nil?
 
@@ -64,7 +66,7 @@ module PsulibTraject
     end
 
     def url_match(link)
-      url_match = PsulibTraject.regex_split link, %r{https*://([\w.]*)}
+      url_match = PsulibTraject.regex_split link, %r{https*://([\w.]*)}i
       url_match[1]
     end
 

--- a/spec/integration/macros_spec.rb
+++ b/spec/integration/macros_spec.rb
@@ -153,6 +153,32 @@ RSpec.describe 'Macros' do
       end
     end
 
+    context 'A record with a url prefix that is not entirely lowercase' do
+      let(:url_856_case_mismatch) do
+        { '856' => { 'ind1' => '0', 'ind2' => '0', 'subfields' => [{ 'u' => 'HtTp://hdl.loc.gov/loc.gmd/g3894p.pm010090' },
+                                                                   { 'z' => 'My Cool Note' }] } }
+      end
+      let(:result_case_mismatch) { indexer.map_record(MARC::Record.new_from_hash('fields' => [url_856_case_mismatch], 'leader' => leader)) }
+
+      it 'produces link data' do
+        expect(result_case_mismatch['full_links_struct']).to match ['{"prefix":"","text":"hdl.loc.gov",'\
+                                                                    '"url":"HtTp://hdl.loc.gov/loc.gmd/g3894p.pm010090","notes":"My Cool Note"}']
+      end
+    end
+
+    context 'A record with no url prefix and starts with "www."' do
+      let(:url_856_case_mismatch) do
+        { '856' => { 'ind1' => '0', 'ind2' => '0', 'subfields' => [{ 'u' => 'www.hdl.loc.gov/loc.gmd/g3894p.pm010090' },
+                                                                   { 'z' => 'My Cool Note' }] } }
+      end
+      let(:result_case_mismatch) { indexer.map_record(MARC::Record.new_from_hash('fields' => [url_856_case_mismatch], 'leader' => leader)) }
+
+      it 'produces link data' do
+        expect(result_case_mismatch['full_links_struct']).to match ['{"prefix":"","text":"www.hdl.loc.gov",'\
+                                                                    '"url":"http://www.hdl.loc.gov/loc.gmd/g3894p.pm010090","notes":"My Cool Note"}']
+      end
+    end
+
     context 'A record with a url that has all subfields for a prefix, label and notes' do
       let(:url_856_8) do
         { '856' => { 'ind1' => '4', 'ind2' => '0', 'subfields' => [{ 'u' => 'http://purl.access.gpo.gov/GPO/LPS47374' },


### PR DESCRIPTION
Closes https://github.com/psu-libraries/psulib_blacklight/issues/428


- allow any combination of upper/lowercase for `http(s)://` prefix
- prepend `http://` to URLs that start with `www.`