### PR TITLE
Parse more genres and separate multiple internal genres

### DIFF
--- a/config/traject.rb
+++ b/config/traject.rb
@@ -265,7 +265,7 @@ to_field 'subject_browse_facet', process_subject_browse_facet(
 to_field 'genre_tsim', extract_marc('650|*0|v:655|*0|abcvxyz:655|*7|abcvxyz')
 
 ## Genre facet (sidebar)
-to_field 'genre_facet', process_genre('650|*0|v:655|*0|abcvxyz:655|*7|ay')
+to_field 'genre_facet', process_genre('650|*0|v:655|*0|abcvxyz:655|*7|abcvxyz')
 
 ## Genre display
 to_field 'genre_display_ssm', process_genre('655|*0|abcvxyz:655|*7|abcvxyz')

--- a/config/traject.rb
+++ b/config/traject.rb
@@ -265,7 +265,7 @@ to_field 'subject_browse_facet', process_subject_browse_facet(
 to_field 'genre_tsim', extract_marc('650|*0|v:655|*0|abcvxyz:655|*7|abcvxyz')
 
 ## Genre facet (sidebar)
-to_field 'genre_facet', process_genre('650|*0|v:655|*0|a:655|*7|a')
+to_field 'genre_facet', process_genre('650|*0|v:655|*0|abcvxyz:655|*7|ay')
 
 ## Genre display
 to_field 'genre_display_ssm', process_genre('655|*0|abcvxyz:655|*7|abcvxyz')

--- a/config/traject.rb
+++ b/config/traject.rb
@@ -271,7 +271,7 @@ to_field 'genre_facet', process_genre('650|*0|v:655|*0|abcvxyz:655|*7|abcvxyz')
 to_field 'genre_display_ssm', process_genre('655|*0|abcvxyz:655|*7|abcvxyz')
 
 ## For genre links
-to_field 'genre_full_facet', extract_marc('650|*0|v:655|*0|abcvxyz:655|*7|abcvxyz'), trim_punctuation
+to_field 'genre_full_facet', process_genre('650|*0|v:655|*0|abcvxyz:655|*7|abcvxyz')
 
 # Call Number fields
 to_field 'lc_1letter_facet', extract_marc('050a') do |_record, accumulator|

--- a/lib/psulib_traject/macros.rb
+++ b/lib/psulib_traject/macros.rb
@@ -16,7 +16,7 @@ module PsulibTraject
         return nil unless record.is_a? MARC::Record
 
         genres = []
-        vocabulary = %w[lcgft fast]
+        vocabulary = %w[lcgft fast rbgenr rbbin rbprov rbpub rbpri aat rbmscv]
         Traject::MarcExtractor.cached(fields).collect_matching_lines(record) do |field, spec, extractor|
           genre = extractor.collect_subfields(field, spec).first
           include_genre = true

--- a/lib/psulib_traject/macros.rb
+++ b/lib/psulib_traject/macros.rb
@@ -17,7 +17,7 @@ module PsulibTraject
 
         genres = []
         vocabulary = %w[lcgft fast rbgenr rbbin rbprov rbpub rbpri aat rbmscv]
-        Traject::MarcExtractor.cached(fields).collect_matching_lines(record) do |field, spec, extractor|
+        Traject::MarcExtractor.cached(fields, { separator: ' - ' }).collect_matching_lines(record) do |field, spec, extractor|
           genre = extractor.collect_subfields(field, spec).first
           include_genre = true
           unless genre.nil?

--- a/spec/integration/macros_spec.rb
+++ b/spec/integration/macros_spec.rb
@@ -252,25 +252,22 @@ RSpec.describe 'Macros' do
   end
 
   describe '#process_genre' do
-    let(:genre650) { { '650' => { 'ind1' => '', 'ind2' => '0', 'subfields' => [{ 'v' => 'Maps' }, { 'z' => 'Tippah County' }] } } }
-    let(:genre655_fast) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Fiction films' }, { 'b' => '1900' }, { '2' => 'fast' }, { 'z' => 'Germany' }] } } }
-    let(:genre655_lcgft) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Drama.' }, { '2' => 'lcgft' }] } } }
-    let(:genre655_aat) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Novels' }, { '2' => 'aat' }] } } }
-    let(:genre655_bogus) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Bogus' }, { '2' => 'bogus' }] } } }
-    let(:genre655_rbgenr) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Periodicals' }, { '2' => 'rbgenr' }] } } }
-    let(:genre655_rbbin) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbbin' }, { '2' => 'rbbin' }] } } }
-    let(:genre655_rbprov) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbprov' }, { '2' => 'rbprov' }] } } }
-    let(:genre655_rbpub) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbpub' }, { '2' => 'rbpub' }] } } }
-    let(:genre655_rbpri) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbpri' }, { '2' => 'rbpri' }] } } }
-    let(:genre655_rbmscv) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbmscv' }, { '2' => 'rbmscv' }] } } }
-    let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [genre650, genre655_fast, genre655_lcgft, 
-                                                                              genre655_aat, genre655_bogus, genre655_rbgenr, 
-                                                                              genre655_rbbin, genre655_rbprov, genre655_rbpub,
-                                                                              genre655_rbpri, genre655_rbmscv], 'leader' => leader)) }
+    let(:genre_fields) { [{ '650' => { 'ind1' => '', 'ind2' => '0', 'subfields' => [{ 'v' => 'Maps' }, { 'z' => 'Tippah County' }] } },
+                          { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Fiction films' }, { 'b' => '1900' }, { '2' => 'fast' }, { 'z' => 'Germany' }] } },
+                          { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Drama.' }, { '2' => 'lcgft' }] } },
+                          { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Novels' }, { '2' => 'aat' }] } },
+                          { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Bogus' }, { '2' => 'bogus' }] } },
+                          { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Periodicals' }, { '2' => 'rbgenr' }] } },
+                          { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbbin' }, { '2' => 'rbbin' }] } },
+                          { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbprov' }, { '2' => 'rbprov' }] } },
+                          { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbpub' }, { '2' => 'rbpub' }] } },
+                          { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbpri' }, { '2' => 'rbpri' }] } },
+                          { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbmscv' }, { '2' => 'rbmscv' }] } }] }
+    let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => genre_fields, 'leader' => leader)) }
 
     it 'limits 655 genres and separates multiple internal genres with a hyphen' do
-      expect(result['genre_display_ssm']).to eq(["Fiction films - 1900 - Germany", "Drama", "Novels", 
-                                                 "Periodicals", "Rbbin", "Rbprov", "Rbpub", "Rbpri", "Rbmscv"])
+      expect(result['genre_display_ssm']).to eq(['Fiction films - 1900 - Germany', 'Drama', 'Novels',
+                                                 'Periodicals', 'Rbbin', 'Rbprov', 'Rbpub', 'Rbpri', 'Rbmscv'])
     end
   end
 

--- a/spec/integration/macros_spec.rb
+++ b/spec/integration/macros_spec.rb
@@ -256,11 +256,21 @@ RSpec.describe 'Macros' do
     let(:genre655_fast) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Fiction films' }, { 'b' => '1900' }, { '2' => 'fast' }, { 'z' => 'Germany' }] } } }
     let(:genre655_lcgft) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Drama.' }, { '2' => 'lcgft' }] } } }
     let(:genre655_aat) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Novels' }, { '2' => 'aat' }] } } }
-    let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [genre650, genre655_fast, genre655_lcgft, genre655_aat], 'leader' => leader)) }
+    let(:genre655_bogus) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Bogus' }, { '2' => 'bogus' }] } } }
+    let(:genre655_rbgenr) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Periodicals' }, { '2' => 'rbgenr' }] } } }
+    let(:genre655_rbbin) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbbin' }, { '2' => 'rbbin' }] } } }
+    let(:genre655_rbprov) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbprov' }, { '2' => 'rbprov' }] } } }
+    let(:genre655_rbpub) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbpub' }, { '2' => 'rbpub' }] } } }
+    let(:genre655_rbpri) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbpri' }, { '2' => 'rbpri' }] } } }
+    let(:genre655_rbmscv) { { '655' => { 'ind1' => '', 'ind2' => '7', 'subfields' => [{ 'a' => 'Rbmscv' }, { '2' => 'rbmscv' }] } } }
+    let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [genre650, genre655_fast, genre655_lcgft, 
+                                                                              genre655_aat, genre655_bogus, genre655_rbgenr, 
+                                                                              genre655_rbbin, genre655_rbprov, genre655_rbpub,
+                                                                              genre655_rbpri, genre655_rbmscv], 'leader' => leader)) }
 
-    it 'limits 655 to fast and lcgft genres' do
-      expect(result['genre_display_ssm']).to include('Fiction films 1900 Germany')
-      expect(result['genre_display_ssm']).to include('Drama')
+    it 'limits 655 genres and separates multiple internal genres with a hyphen' do
+      expect(result['genre_display_ssm']).to eq(["Fiction films - 1900 - Germany", "Drama", "Novels", 
+                                                 "Periodicals", "Rbbin", "Rbprov", "Rbpub", "Rbpri", "Rbmscv"])
     end
   end
 


### PR DESCRIPTION
Also, adds more subfields to be parsed for the genre facet.  The same subfields the main genre field uses.

closes #185 