### PR TITLE
Split 653a on semicolon

### DIFF
--- a/config/traject.rb
+++ b/config/traject.rb
@@ -238,7 +238,7 @@ to_field 'language_facet', marc_languages('008[35-37]')
 to_field 'subject_tsim', extract_marc('600abcdfklmnopqrtvxyz:610abfklmnoprstvxyz:611abcdefgklnpqstvxyz:630adfgklmnoprstvxyz:647acdg:648a:650abcd:651a:653a:654ab')
 
 ## Other Subject
-to_field 'subject_other_display_ssm', extract_marc('653a'), split(';'), trim_punctuation
+to_field 'subject_other_display_ssm', extract_marc('653a'), strip, split(';'), trim_punctuation
 
 ## Additional subject fields
 to_field 'subject_addl_tsim', extract_marc('600vxyz:610vxyz:611vxyz:630vxyz:647vxyz:648vxyz:650vxyz:651vxyz:654vyz')

--- a/config/traject.rb
+++ b/config/traject.rb
@@ -238,7 +238,7 @@ to_field 'language_facet', marc_languages('008[35-37]')
 to_field 'subject_tsim', extract_marc('600abcdfklmnopqrtvxyz:610abfklmnoprstvxyz:611abcdefgklnpqstvxyz:630adfgklmnoprstvxyz:647acdg:648a:650abcd:651a:653a:654ab')
 
 ## Other Subject
-to_field 'subject_other_display_ssm', extract_marc('653a'), trim_punctuation
+to_field 'subject_other_display_ssm', extract_marc('653a'), split(';'), trim_punctuation
 
 ## Additional subject fields
 to_field 'subject_addl_tsim', extract_marc('600vxyz:610vxyz:611vxyz:630vxyz:647vxyz:648vxyz:650vxyz:651vxyz:654vyz')

--- a/spec/integration/config_spec.rb
+++ b/spec/integration/config_spec.rb
@@ -132,10 +132,11 @@ RSpec.describe 'Config' do
     let(:other_subjects_653) do
       { '653' => { 'subfields' => [{ 'a' => 'One;Two ; Three; Four; ' }] } }
     end
+
     it 'removes leading and trailing whitespace and separates other subjects on ";"' do
       result = indexer.map_record(MARC::Record.new_from_hash('fields' => [other_subjects_653], 'leader' => leader))
 
-      expect(result['subject_other_display_ssm']).to eq ["One", "Two", "Three", "Four"]
+      expect(result['subject_other_display_ssm']).to eq ['One', 'Two', 'Three', 'Four']
     end
   end
 end

--- a/spec/integration/config_spec.rb
+++ b/spec/integration/config_spec.rb
@@ -127,4 +127,15 @@ RSpec.describe 'Config' do
       expect(result['ht_access_ss']).to contain_exactly 'allow'
     end
   end
+
+  describe 'extracting other subjects' do
+    let(:other_subjects_653) do
+      { '653' => { 'subfields' => [{ 'a' => 'One;Two ; Three; Four; ' }] } }
+    end
+    it 'removes leading and trailing whitespace and separates other subjects on ";"' do
+      result = indexer.map_record(MARC::Record.new_from_hash('fields' => [other_subjects_653], 'leader' => leader))
+
+      expect(result['subject_other_display_ssm']).to eq ["One", "Two", "Three", "Four"]
+    end
+  end
 end


### PR DESCRIPTION
Stripping leading and trailing whitespace from 653a's and splitting 653a into separate items on ';'s.

closes #416 
