### PR TITLE
use jdk17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jruby:9.3.9.0
+FROM jruby:9.3.9.0-jdk17
 WORKDIR /app
 ARG UID=3000
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -246,11 +246,11 @@ GEM
     yell (2.2.2)
 
 PLATFORMS
-  universal-java-1.8
   universal-java-10
   universal-java-11
   universal-java-14
   universal-java-15
+  universal-java-17
   x86_64-darwin-20
   x86_64-linux
 


### PR DESCRIPTION
updates JDK for traject. We should be able to cut a release of traject, and do a full index, we'll test indexing in to the -green deployemnt first. we've indexed into qa multiple times succesfully after these tweaks, and tweaks to the catalog config