### PR TITLE
Track hourlies by collection, not alias 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ COPY --chown=app Gemfile Gemfile.lock /app/
 RUN gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"
 RUN bundle install
 
-COPY . /app
+COPY --chown=app . /app
 
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -17,6 +17,9 @@ commit_timeout: 10000
 symphony_data_path: "<%= ENV.fetch('SYMPHONY_DATA_PATH', '/data/symphony_data') %>"
 # Folder within `symphony_data_path` where hourlies are stored
 symphony_hourlies_subdir: hourlies
+# How long to keep the hourlies skip keys
+# we keep hourlies for 7 days, so we keep the lock for 10 to overlap
+hourlies_skip_expire_seconds: 864000
 hathi_etas: false
 hathi_overlap_path: "<%= ENV.fetch('HATHI_OVERLAP_PATH', '/data/hathitrust_data/overlap.tsv') %>"
 marc4j_reader:

--- a/lib/psulib_traject/solr_manager.rb
+++ b/lib/psulib_traject/solr_manager.rb
@@ -10,6 +10,11 @@ module PsulibTraject
       collections_with_prefix.max_by(&:version_number)
     end
 
+    def current_collection
+      resp = connection.get('/solr/admin/collections?action=LISTALIASES')
+      JSON.parse(resp.body)&.dig('aliases')&.dig(ConfigSettings.solr.collection) || ConfigSettings.solr.collection
+    end
+
     def query_url
       query_url = "#{url}/#{ConfigSettings.solr.collection}"
       return query_url if ConfigSettings.solr.username.empty? && ConfigSettings.solr.password.empty?

--- a/lib/tasks/traject.rake
+++ b/lib/tasks/traject.rake
@@ -16,9 +16,10 @@ namespace :traject do
     PsulibTraject::Workers::HourlyIndexer.perform_now
   end
 
-  desc 'Clear redis of hourly semaphores'
+  desc 'Clear redis of hourly skip list'
   task :clear_hourlies do
+    current_collection = PsulibTraject::SolrManager.new.current_collection
     redis = Redis.new
-    redis.keys('hr:*').map { |key| redis.del(key) }
+    redis.keys("#{current_collection}:*").map { |key| redis.del(key) }
   end
 end

--- a/spec/lib/psulib_traject/workers/hourly_indexer_spec.rb
+++ b/spec/lib/psulib_traject/workers/hourly_indexer_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe PsulibTraject::Workers::HourlyIndexer do
           body: '',
           headers: {}
         )
+      stub_request(
+        :get, /.*#{ConfigSettings.solr.host}:#{ConfigSettings.solr.port}\/solr\/admin\/collections\?action=LISTALIASES/
+      )
+        .to_return(
+          status: 200,
+          body: { "aliases": {} }.to_json,
+          headers: {}
+        )
     end
 
     it 'submits jobs for each hourly file' do


### PR DESCRIPTION
- figures out what the collection name is if using an alias
- uses that collection name as a key in redis to track hourlies


This allows us to process hourlies _before_ flipping the collection on a full re-index.