### PR TITLE
Store callnumber if record is 'In the Library'

### DIFF
--- a/lib/psulib_traject/holdings.rb
+++ b/lib/psulib_traject/holdings.rb
@@ -22,7 +22,7 @@ module PsulibTraject
     end
 
     def resolve_base
-      return [] if online? || holdings.empty?
+      return [] if not_in_the_library? || holdings.empty?
 
       holdings.reject! do |call_number|
         call_number.exclude? || call_number.not_browsable?
@@ -39,8 +39,8 @@ module PsulibTraject
 
     private
 
-      def online?
-        context.output_hash['access_facet']&.include?('Online')
+      def not_in_the_library?
+        !context.output_hash['access_facet']&.include?('In the Library')
       end
 
       # assuming each 949 has only one subfield a, w and l

--- a/spec/lib/psulib_traject/holdings_spec.rb
+++ b/spec/lib/psulib_traject/holdings_spec.rb
@@ -31,13 +31,37 @@ RSpec.describe PsulibTraject::Holdings do
   end
 
   describe '#call' do
+    let(:context) { instance_spy('Traject::Indexer::Context',
+                                 output_hash: { 'access_facet' => ['Online', 'In the Library', 'Free to Read'] }) }
+
     context 'with an empty record' do
       it { is_expected.to be_empty }
     end
 
-    context 'with an online record' do
+    context 'with an online record that is also "In the Library"' do
+      let(:fields) do
+        [MARC::DataField.new('949', '', '', ['a', 'AB123 .C456 2000 LC Call Number'], ['w', 'LC'], ['l', 'Location'])]
+      end
+
+      it { is_expected.to contain_exactly 'AB123 .C456 2000 LC Call Number' }
+    end
+
+    context 'with an online record that is not "In the Library"' do
+      let(:fields) do
+        [MARC::DataField.new('949', '', '', ['a', 'AB123 .C456 2000 LC Call Number'], ['w', 'LC'], ['l', 'Location'])]
+      end
       let(:context) { instance_spy('Traject::Indexer::Context',
-                                   output_hash: { access_facet: ['Online', 'In the Library', 'Free to Read'] }) }
+                                   output_hash: { 'access_facet' => ['Online', 'Free to Read'] }) }
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'with a record that is not online or "In the Library"' do
+      let(:fields) do
+        [MARC::DataField.new('949', '', '', ['a', 'AB123 .C456 2000 LC Call Number'], ['w', 'LC'], ['l', 'Location'])]
+      end
+      let(:context) { instance_spy('Traject::Indexer::Context',
+                                   output_hash: { 'access_facet' => ['Free to Read'] }) }
 
       it { is_expected.to be_empty }
     end


### PR DESCRIPTION
Replaced `online?` method in `holdings.rb` with `not_in_the_library?` method that checks if the record's `access_facet` includes 'In the Library'.  If a record is not in the library it will not have a callnumber.  On the other hand, _anything_ (including records that are also online) that is in the library will have a callnumber.  Added some tests to test a couple different variations of `access_facets`.