### PR TITLE
Thesis Department index

### DIFF
--- a/config/traject.rb
+++ b/config/traject.rb
@@ -574,6 +574,7 @@ to_field 'bound_with_struct' do |record, accumulator|
 end
 
 # 699a Thesis Department
+to_field 'thesis_dept_display_ssm', extract_marc('699a'), trim_punctuation, include_psu_theses_only
 to_field 'thesis_dept_facet', extract_marc('699a'), trim_punctuation, include_psu_theses_only
 
 # 773 - "Part Of"

--- a/lib/psulib_traject/macros.rb
+++ b/lib/psulib_traject/macros.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 NOT_FULLTEXT = /addendum|appendices|appendix|appendixes|cover|excerpt|executive summary|index/i.freeze
-PSU_THESIS_CODE = /THESIS-B|THESIS-D|THESIS-M/.freeze
+PSU_THESIS_CODE = /THESIS-D|THESIS-M/.freeze
 ESTIMATE_TOLERANCE = 15
 MIN_YEAR = 500
 MAX_YEAR = Time.new.year + 6

--- a/spec/integration/macros_spec.rb
+++ b/spec/integration/macros_spec.rb
@@ -202,6 +202,7 @@ RSpec.describe 'Macros' do
     let(:thesis_dept_699) do
       { '699' => { 'subfields' => [{ 'a' => 'Acoustics.' }] } }
     end
+    let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [thesis_dept_699, code_949], 'leader' => leader)) }
 
     context 'when a record has no 949t fields' do
       let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [thesis_dept_699], 'leader' => leader)) }
@@ -216,36 +217,28 @@ RSpec.describe 'Macros' do
         { '949' => { 'subfields' => [{ 'a' => 'Thesis 2011mOrr,A', 't' => 'THESIS-B' }] } }
       end
 
-      let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [thesis_dept_699, code_949], 'leader' => leader)) }
-
       it 'does not index the theses department data' do
         expect(result['thesis_dept_facet']).to be_nil
       end
     end
 
-    context 'when a record does have a PSU thesis code' do
-      context 'when thesis code is THESIS-D' do
-        let(:code_949) do
-          { '949' => { 'subfields' => [{ 'a' => 'Thesis 2011mOrr,A', 't' => 'THESIS-D' }] } }
-        end
-
-        let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [thesis_dept_699, code_949], 'leader' => leader)) }
-
-        it 'indexes the theses department data' do
-          expect(result['thesis_dept_facet']).to eq ['Acoustics']
-        end
+    context 'when thesis code is THESIS-D' do
+      let(:code_949) do
+        { '949' => { 'subfields' => [{ 'a' => 'Thesis 2011mOrr,A', 't' => 'THESIS-D' }] } }
       end
 
-      context 'when thesis code is THESIS-M' do
-        let(:code_949) do
-          { '949' => { 'subfields' => [{ 'a' => 'Thesis 2011mOrr,A', 't' => 'THESIS-M' }] } }
-        end
+      it 'indexes the theses department data' do
+        expect(result['thesis_dept_facet']).to eq ['Acoustics']
+      end
+    end
 
-        let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [thesis_dept_699, code_949], 'leader' => leader)) }
+    context 'when thesis code is THESIS-M' do
+      let(:code_949) do
+        { '949' => { 'subfields' => [{ 'a' => 'Thesis 2011mOrr,A', 't' => 'THESIS-M' }] } }
+      end
 
-        it 'indexes the theses department data' do
-          expect(result['thesis_dept_facet']).to eq ['Acoustics']
-        end
+      it 'indexes the theses department data' do
+        expect(result['thesis_dept_facet']).to eq ['Acoustics']
       end
     end
   end

--- a/spec/integration/macros_spec.rb
+++ b/spec/integration/macros_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe 'Macros' do
 
     context 'when a record does not have a PSU thesis code' do
       let(:code_949) do
-        { '949' => { 'subfields' => [{ 'a' => 'Thesis 2011mOrr,A', 't' => 'THESIS-A' }] } }
+        { '949' => { 'subfields' => [{ 'a' => 'Thesis 2011mOrr,A', 't' => 'THESIS-B' }] } }
       end
 
       let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [thesis_dept_699, code_949], 'leader' => leader)) }
@@ -224,14 +224,28 @@ RSpec.describe 'Macros' do
     end
 
     context 'when a record does have a PSU thesis code' do
-      let(:code_949) do
-        { '949' => { 'subfields' => [{ 'a' => 'Thesis 2011mOrr,A', 't' => 'THESIS-B' }] } }
+      context 'when thesis code is THESIS-D' do
+        let(:code_949) do
+          { '949' => { 'subfields' => [{ 'a' => 'Thesis 2011mOrr,A', 't' => 'THESIS-D' }] } }
+        end
+
+        let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [thesis_dept_699, code_949], 'leader' => leader)) }
+
+        it 'indexes the theses department data' do
+          expect(result['thesis_dept_facet']).to eq ['Acoustics']
+        end
       end
 
-      let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [thesis_dept_699, code_949], 'leader' => leader)) }
+      context 'when thesis code is THESIS-M' do
+        let(:code_949) do
+          { '949' => { 'subfields' => [{ 'a' => 'Thesis 2011mOrr,A', 't' => 'THESIS-M' }] } }
+        end
 
-      it 'indexes the theses department data' do
-        expect(result['thesis_dept_facet']).to eq ['Acoustics']
+        let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [thesis_dept_699, code_949], 'leader' => leader)) }
+
+        it 'indexes the theses department data' do
+          expect(result['thesis_dept_facet']).to eq ['Acoustics']
+        end
       end
     end
   end


### PR DESCRIPTION
Adds thesis_dept display field to traject extracts.  Removes 'THESIS-B' from thesis codes allowed to be indexed.

closes #305 

blacklight side: https://github.com/psu-libraries/psulib_blacklight/pull/1199