### PR TITLE
right to left language formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,6 @@ config/environments/*.local.yml
 .bash_history
 .cache
 .local
+.envrc
 data/
 vendor/**/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,7 @@ RSpec/NestedGroups:
     - 'spec/lib/psulib_traject/processors/call_number/lc_spec.rb'
     - 'spec/lib/psulib_traject/processors/call_number/dewey_spec.rb'
     - 'spec/lib/psulib_traject/processors/title_display_spec.rb'
+    - 'spec/lib/psulib_traject/processors/pub_display_spec.rb'
 
 RSpec/ExpectActual:
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,7 @@ PLATFORMS
   universal-java-14
   universal-java-15
   universal-java-17
+  universal-java-19
   x86_64-darwin-20
   x86_64-linux
 
@@ -281,4 +282,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.2.20
+   2.2.33

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,4 +282,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.2.33
+   2.2.20

--- a/config/traject.rb
+++ b/config/traject.rb
@@ -218,13 +218,23 @@ to_field 'publisher_manufacturer_tsim', extract_marc('260b:264|*1|b:260f:264|*3|
 to_field 'pub_date_itsi', process_publication_date
 
 ## Publication fields for display
-to_field 'publication_display_ssm', extract_marc('260abcefg3:264|*1|abc3') # display in search results
-to_field 'overall_imprint_display_ssm', extract_marc('260abcefg3:264|*0|abc3:264|*1|abc3:264|*2|abc3:264|*3|abc3') # display on single item page
 to_field 'copyright_display_ssm', extract_marc('264|*4|c')
-to_field 'edition_display_ssm', extract_marc('250ab3')
 to_field 'cartographic_mathematical_data_ssm', extract_marc('255abcdefg')
 to_field 'other_edition_ssm', extract_marc('775|0*|iabcdefghkmnor')
 to_field 'collection_facet', extract_marc('793a')
+# use formatted *_vern in *_display_ssm if exists
+# otherwise use *_latin as *_display_ssm
+to_field 'publication_latin', extract_marc('260abcefg3:264|*1|abc3', alternate_script: false) # display in search results
+to_field 'publication_vern', extract_marc('260abcefg3:264|*1|abc3', alternate_script: :only) # display in search results
+to_field 'overall_imprint_latin', extract_marc('260abcefg3:264|*0|abc3:264|*1|abc3:264|*2|abc3:264|*3|abc3', alternate_script: false) # display on single item page
+to_field 'overall_imprint_vern', extract_marc('260abcefg3:264|*0|abc3:264|*1|abc3:264|*2|abc3:264|*3|abc3', alternate_script: :only) # display on single item page
+to_field 'edition_latin', extract_marc('250ab3', alternate_script: false)
+to_field 'edition_vern', extract_marc('250ab3', alternate_script: :only)
+each_record do |_record, context|
+  PsulibTraject::Processors::PubDisplay.new('publication', context).call
+  PsulibTraject::Processors::PubDisplay.new('overall_imprint', context).call
+  PsulibTraject::Processors::PubDisplay.new('edition', context).call
+end
 
 ## Publication fields for Illiad and Aeon
 to_field 'pub_date_illiad_ssm', extract_marc('260c:264|*1|c'), trim_punctuation

--- a/config/traject.rb
+++ b/config/traject.rb
@@ -222,14 +222,10 @@ to_field 'copyright_display_ssm', extract_marc('264|*4|c')
 to_field 'cartographic_mathematical_data_ssm', extract_marc('255abcdefg')
 to_field 'other_edition_ssm', extract_marc('775|0*|iabcdefghkmnor')
 to_field 'collection_facet', extract_marc('793a')
-# use formatted *_vern in *_display_ssm if exists
-# otherwise use *_latin as *_display_ssm
-to_field 'publication_latin', extract_marc('260abcefg3:264|*1|abc3', alternate_script: false) # display in search results
-to_field 'publication_vern', extract_marc('260abcefg3:264|*1|abc3', alternate_script: :only) # display in search results
-to_field 'overall_imprint_latin', extract_marc('260abcefg3:264|*0|abc3:264|*1|abc3:264|*2|abc3:264|*3|abc3', alternate_script: false) # display on single item page
-to_field 'overall_imprint_vern', extract_marc('260abcefg3:264|*0|abc3:264|*1|abc3:264|*2|abc3:264|*3|abc3', alternate_script: :only) # display on single item page
-to_field 'edition_latin', extract_marc('250ab3', alternate_script: false)
-to_field 'edition_vern', extract_marc('250ab3', alternate_script: :only)
+to_field 'publication_display_ssm', extract_marc('260abcefg3:264|*1|abc3') # display in search results
+to_field 'overall_imprint_display_ssm', extract_marc('260abcefg3:264|*0|abc3:264|*1|abc3:264|*2|abc3:264|*3|abc3') # display on single item page
+to_field 'edition_display_ssm', extract_marc('250ab3')
+# processes display fields to help format vernacular display
 each_record do |_record, context|
   PsulibTraject::Processors::PubDisplay.new('publication', context).call
   PsulibTraject::Processors::PubDisplay.new('overall_imprint', context).call

--- a/lib/psulib_traject.rb
+++ b/lib/psulib_traject.rb
@@ -34,6 +34,7 @@ module PsulibTraject
   require 'psulib_traject/processors/record_type'
   require 'psulib_traject/processors/summary_holdings'
   require 'psulib_traject/processors/title_display'
+  require 'psulib_traject/processors/pub_display'
   require 'psulib_traject/processors/oclc_extract'
   require 'psulib_traject/shelf_key'
   require 'psulib_traject/solr_manager'

--- a/lib/psulib_traject/processors/pub_display.rb
+++ b/lib/psulib_traject/processors/pub_display.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module PsulibTraject::Processors
+  class PubDisplay
+    def initialize(field, context)
+      @context = context
+      @field = field
+    end
+
+    def call
+      if vern.nil?
+        context.output_hash[final] = latin
+        # remove duplicate latin version
+        context.output_hash.delete("#{field}_latin")
+      else
+        context.output_hash[final] = [latin.first, vern_clean]
+        # remove duplicate versions
+        context.output_hash.delete("#{field}_latin")
+        context.output_hash.delete("#{field}_vern")
+      end
+    end
+
+    private
+
+      attr_accessor :context, :field
+
+      def latin
+        context.output_hash["#{field}_latin"]
+      end
+
+      def vern
+        context.output_hash["#{field}_vern"]
+      end
+
+      def final
+        "#{field}_display_ssm"
+      end
+
+      def vern_clean
+        vern_value = vern.first
+        return vern_value unless /[\u0621-\u064A]+\.$/.match?(vern_value) # regex to check for arabic
+
+        vern_value = vern_value.gsub('.', '')
+        ".#{vern_value}"
+      end
+  end
+end

--- a/lib/psulib_traject/processors/pub_display.rb
+++ b/lib/psulib_traject/processors/pub_display.rb
@@ -8,39 +8,27 @@ module PsulibTraject::Processors
     end
 
     def call
-      if vern.nil?
-        context.output_hash[final] = latin
-        # remove duplicate latin version
-        context.output_hash.delete("#{field}_latin")
-      else
-        context.output_hash[final] = [latin.first, vern_clean]
-        # remove duplicate versions
-        context.output_hash.delete("#{field}_latin")
-        context.output_hash.delete("#{field}_vern")
-      end
+      return if final.nil?
+
+      final[1] = vern_clean unless vern.nil?
     end
 
     private
 
       attr_accessor :context, :field
 
-      def latin
-        context.output_hash["#{field}_latin"]
-      end
-
       def vern
-        context.output_hash["#{field}_vern"]
+        final.length <= 1 ? nil : final[1]
       end
 
       def final
-        "#{field}_display_ssm"
+        context.output_hash["#{field}_display_ssm"]
       end
 
       def vern_clean
-        vern_value = vern.first
-        return vern_value unless /[\u0621-\u064A]+\.$/.match?(vern_value) # regex to check for arabic
+        return vern unless /[\u0621-\u064A]+\.$/.match?(vern) # regex to check for arabic
 
-        vern_value = vern_value.gsub('.', '')
+        vern_value = vern.gsub('.', '')
         ".#{vern_value}"
       end
   end

--- a/spec/integration/publication_spec.rb
+++ b/spec/integration/publication_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec::Matchers.define_negated_matcher :not_include, :include
+
+RSpec.describe 'Publication' do
+  let(:leader) { '1234567890' }
+
+  describe 'Record with a right to left vernacular edition' do
+    let(:field) { 'edition_display_ssm' }
+    let(:edition_250) do
+      { '250' => { 'subfields' => [{ '6' => '880-03' },
+                                   { 'a' => 'Chāp-i avval.' }] } }
+    end
+    let(:edition_vern_250) do
+      { '880' => { 'subfields' => [{ '6' => '250-03' },
+                                   { 'a' => 'چاپ اول.' }] } }
+    end
+    let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [edition_250, edition_vern_250], 'leader' => leader)) }
+
+    it 'has the vernacular edition with a period on the left in the edition statement' do
+      expect(result[field]).to eq ['Chāp-i avval.', '.چاپ اول']
+      expect(result[field].length).to eq 2
+    end
+
+    it 'has empty vern and latin edition field' do
+      expect(result).not_to include('edition_vern')
+      expect(result).not_to include('edition_latin')
+    end
+  end
+
+  describe 'Record with a left to right vernacular edition' do
+    let(:field) { 'edition_display_ssm' }
+    let(:edition_250) do
+      { '250' => { 'subfields' => [{ '6' => '880-03' },
+                                   { 'a' => 'Tōkyō : Hayakawa Shobō, 1999.' }] } }
+    end
+    let(:edition_vern_250) do
+      { '880' => { 'subfields' => [{ '6' => '250-03' },
+                                   { 'a' => '東京 : 早川書房, 1999.' }] } }
+    end
+    let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [edition_250, edition_vern_250], 'leader' => leader)) }
+
+    it 'has the vernacular edition with a period on the right in the edition statement' do
+      expect(result[field]).to eq ['Tōkyō : Hayakawa Shobō, 1999.', '東京 : 早川書房, 1999.']
+      expect(result[field].length).to eq 2
+    end
+
+    it 'has empty vern and latin edition field' do
+      expect(result).not_to include('edition_vern')
+      expect(result).not_to include('edition_latin')
+    end
+  end
+
+  describe 'Record with no vernacular edition' do
+    let(:field) { 'edition_display_ssm' }
+    let(:edition_250) do
+      { '250' => { 'subfields' => [{ '6' => '880-03' },
+                                   { 'a' => 'First Edition.' }] } }
+    end
+    let(:result) { indexer.map_record(MARC::Record.new_from_hash('fields' => [edition_250], 'leader' => leader)) }
+
+    it 'has the vernacular edition with a period on the right in the edition statement' do
+      expect(result[field]).to eq ['First Edition.']
+      expect(result[field].length).to eq 1
+    end
+
+    it 'has empty vern and latin edition field' do
+      expect(result).not_to include('edition_vern')
+      expect(result).not_to include('edition_latin')
+    end
+  end
+end

--- a/spec/lib/psulib_traject/processors/pub_display_spec.rb
+++ b/spec/lib/psulib_traject/processors/pub_display_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe PsulibTraject::Processors::PubDisplay do
+  let(:context) { instance_double 'Context' }
+
+  before do
+    allow(context).to receive(:output_hash).and_return(output_hash)
+  end
+
+  describe '::call' do
+    context 'when there is not a vernacular version of the field' do
+      let(:output_hash) do
+        { 'edition_vern' => nil,
+          'edition_display_ssm' => nil,
+          'edition_latin' => ['thing'] }
+      end
+
+      it 'sets the field_display_ssm to the field_latin and deletes field_latin' do
+        described_class.new('edition', context).call
+        expect(output_hash['edition_display_ssm']).to eq ['thing']
+        expect(output_hash['edition_latin']).to eq nil
+      end
+    end
+
+    context 'when there is a vernacular version of the field' do
+      context 'when field_vern contains right to left arabic equals sign' do
+        context 'when there is a period on the right end of field_vern' do
+          let(:output_hash) do
+            { 'edition_vern' => ['چاپ اول.'],
+              'edition_display_ssm' => nil,
+              'edition_latin' => ['Chāp-i avval.'] }
+          end
+
+          it 'moves the period of the vern to the left, adds field_latin & field_vern to field_display_ssm, and deletes field_latin and field_vern' do
+            described_class.new('edition', context).call
+            expect(output_hash['edition_display_ssm']).to eq ['Chāp-i avval.', '.چاپ اول']
+            expect(output_hash['edition_latin']).to eq nil
+            expect(output_hash['edition_vern']).to eq nil
+          end
+        end
+
+        context 'when there is not a period on the right end of field_vern' do
+          let(:output_hash) do
+            { 'edition_vern' => ['چاپ اول'],
+              'edition_display_ssm' => nil,
+              'edition_latin' => ['Chāp-i avval.'] }
+          end
+
+          it 'does not change the field_vern, adds field_latin & field_vern to field_display_ssm, and deletes field_latin and field_vern' do
+            described_class.new('edition', context).call
+            expect(output_hash['edition_display_ssm']).to eq ['Chāp-i avval.', 'چاپ اول']
+            expect(output_hash['edition_latin']).to eq nil
+            expect(output_hash['edition_vern']).to eq nil
+          end
+        end
+      end
+
+      context 'when field_vern does not contain right to left arabic equals sign' do
+        let(:output_hash) do
+          { 'edition_vern' => ['東京 : 早川書房, 1999.'],
+            'edition_display_ssm' => nil,
+            'edition_latin' => ['Tōkyō : Hayakawa Shobō, 1999.'] }
+        end
+
+        it 'adds field_latin & field_vern to field_display_ssm and deletes field_latin and field_vern' do
+          described_class.new('edition', context).call
+          expect(output_hash['edition_display_ssm']).to eq ['Tōkyō : Hayakawa Shobō, 1999.', '東京 : 早川書房, 1999.']
+          expect(output_hash['edition_latin']).to eq nil
+          expect(output_hash['edition_vern']).to eq nil
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/psulib_traject/processors/pub_display_spec.rb
+++ b/spec/lib/psulib_traject/processors/pub_display_spec.rb
@@ -10,15 +10,12 @@ RSpec.describe PsulibTraject::Processors::PubDisplay do
   describe '::call' do
     context 'when there is not a vernacular version of the field' do
       let(:output_hash) do
-        { 'edition_vern' => nil,
-          'edition_display_ssm' => nil,
-          'edition_latin' => ['thing'] }
+        { 'edition_display_ssm' => ['thing'] }
       end
 
       it 'sets the field_display_ssm to the field_latin and deletes field_latin' do
         described_class.new('edition', context).call
         expect(output_hash['edition_display_ssm']).to eq ['thing']
-        expect(output_hash['edition_latin']).to eq nil
       end
     end
 
@@ -26,47 +23,35 @@ RSpec.describe PsulibTraject::Processors::PubDisplay do
       context 'when field_vern contains right to left arabic equals sign' do
         context 'when there is a period on the right end of field_vern' do
           let(:output_hash) do
-            { 'edition_vern' => ['چاپ اول.'],
-              'edition_display_ssm' => nil,
-              'edition_latin' => ['Chāp-i avval.'] }
+            { 'edition_display_ssm' => ['Chāp-i avval.', 'چاپ اول.'] }
           end
 
           it 'moves the period of the vern to the left, adds field_latin & field_vern to field_display_ssm, and deletes field_latin and field_vern' do
             described_class.new('edition', context).call
             expect(output_hash['edition_display_ssm']).to eq ['Chāp-i avval.', '.چاپ اول']
-            expect(output_hash['edition_latin']).to eq nil
-            expect(output_hash['edition_vern']).to eq nil
           end
         end
 
         context 'when there is not a period on the right end of field_vern' do
           let(:output_hash) do
-            { 'edition_vern' => ['چاپ اول'],
-              'edition_display_ssm' => nil,
-              'edition_latin' => ['Chāp-i avval.'] }
+            { 'edition_display_ssm' => ['Chāp-i avval.', 'چاپ اول'] }
           end
 
           it 'does not change the field_vern, adds field_latin & field_vern to field_display_ssm, and deletes field_latin and field_vern' do
             described_class.new('edition', context).call
             expect(output_hash['edition_display_ssm']).to eq ['Chāp-i avval.', 'چاپ اول']
-            expect(output_hash['edition_latin']).to eq nil
-            expect(output_hash['edition_vern']).to eq nil
           end
         end
       end
 
       context 'when field_vern does not contain right to left arabic equals sign' do
         let(:output_hash) do
-          { 'edition_vern' => ['東京 : 早川書房, 1999.'],
-            'edition_display_ssm' => nil,
-            'edition_latin' => ['Tōkyō : Hayakawa Shobō, 1999.'] }
+          { 'edition_display_ssm' => ['Tōkyō : Hayakawa Shobō, 1999.', '東京 : 早川書房, 1999.'] }
         end
 
         it 'adds field_latin & field_vern to field_display_ssm and deletes field_latin and field_vern' do
           described_class.new('edition', context).call
           expect(output_hash['edition_display_ssm']).to eq ['Tōkyō : Hayakawa Shobō, 1999.', '東京 : 早川書房, 1999.']
-          expect(output_hash['edition_latin']).to eq nil
-          expect(output_hash['edition_vern']).to eq nil
         end
       end
     end


### PR DESCRIPTION
Fixes #176 

New processor moves period to the left side for vernacular publication fields in right to left languages