### PR TITLE
Sidekiq update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem 'marc'
 gem 'rake'
 gem 'rsolr'
 gem 'shelvit'
-gem 'sidekiq'
-gem 'sidekiq-scheduler'
+gem 'sidekiq', '~> 6.5'
+gem 'sidekiq-scheduler', '~> 4.0'
 gem 'traject'
 gem 'traject-marc4j_reader', platform: :jruby
 gem 'whenever', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     config (3.1.0)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
-    connection_pool (2.2.5)
+    connection_pool (2.4.1)
     crack (0.4.5)
       rexml
     deep_merge (1.2.1)
@@ -55,8 +55,7 @@ GEM
       dry-equalizer (~> 0.2)
       dry-initializer (~> 3.0)
       dry-schema (~> 1.5, >= 1.5.2)
-    e2mmap (0.1.0)
-    et-orbi (1.2.4)
+    et-orbi (1.2.7)
       tzinfo
     faker (3.2.0)
       i18n (>= 1.8.11, < 2)
@@ -78,8 +77,8 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fugit (1.5.0)
-      et-orbi (~> 1.1, >= 1.1.8)
+    fugit (1.9.0)
+      et-orbi (~> 1, >= 1.2.7)
       raabro (~> 1.4)
     hashdiff (1.0.1)
     hashie (4.1.0)
@@ -141,10 +140,10 @@ GEM
     raabro (1.4.0)
     racc (1.6.1)
     racc (1.6.1-java)
-    rack (2.2.6.4)
+    rack (2.2.8)
     rainbow (3.1.1)
     rake (13.0.3)
-    redis (4.5.1)
+    redis (4.8.1)
     regexp_parser (2.8.0)
     rexml (3.2.5)
     rsolr (2.3.0)
@@ -195,21 +194,19 @@ GEM
     ruby-debug-base (0.11.0-java)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.4)
-    rufus-scheduler (3.8.0)
+    rufus-scheduler (3.9.1)
       fugit (~> 1.1, >= 1.1.6)
     scrub_rb (1.0.1)
     shelvit (0.1.2)
       lcsort (~> 0.9)
-    sidekiq (6.4.0)
-      connection_pool (>= 2.2.2)
+    sidekiq (6.5.12)
+      connection_pool (>= 2.2.5, < 3)
       rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
+    sidekiq-scheduler (4.0.3)
       redis (>= 4.2.0)
-    sidekiq-scheduler (3.1.0)
-      e2mmap
-      redis (>= 3, < 5)
       rufus-scheduler (~> 3.2)
-      sidekiq (>= 3)
-      thwait
+      sidekiq (>= 4, < 7)
       tilt (>= 1.4.0)
     simplecov (0.17.1)
       docile (~> 1.1)
@@ -219,9 +216,7 @@ GEM
     slop (4.9.1)
     spoon (0.0.6)
       ffi
-    thwait (0.2.0)
-      e2mmap
-    tilt (2.0.10)
+    tilt (2.3.0)
     traject (3.5.0)
       concurrent-ruby (>= 0.8.0)
       dot-properties (>= 0.1.1)
@@ -236,7 +231,7 @@ GEM
     traject-marc4j_reader (1.1.0-java)
       marc (~> 1.0)
       marc-marc4j (~> 1.0)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
       unf_ext
@@ -279,8 +274,8 @@ DEPENDENCIES
   rubocop-performance (~> 1.1)
   rubocop-rspec (~> 2)
   shelvit
-  sidekiq
-  sidekiq-scheduler
+  sidekiq (~> 6.5)
+  sidekiq-scheduler (~> 4.0)
   simplecov (< 0.18)
   traject
   traject-marc4j_reader

--- a/spec/lib/psulib_traject/workers/hourly_indexer_spec.rb
+++ b/spec/lib/psulib_traject/workers/hourly_indexer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe PsulibTraject::Workers::HourlyIndexer do
 
   before(:all) do
     redis = Redis.new
-    redis.keys('hr:*').map { |key| redis.del(key) }
+    redis.keys.map { |key| redis.del(key) }
   end
 
   before do


### PR DESCRIPTION
Bumping sidekiq required sidekiq-scheduler to be upgraded as well.

The hourly indexer spec was failing. It seemed like it was only removing keys that had `hr` but none of them did, so it wasn't actually removing anything.