### PR TITLE
503 - Grabs 857 field if it starts with ark

### DIFF
--- a/config/traject.rb
+++ b/config/traject.rb
@@ -629,7 +629,15 @@ to_field 'serials_changed_back_to_display_ssim', extract_marc('785|08|t')
 # 799a - Sublocation
 # From our catalog experts: "The data in this field corresponds to "collections" within Special Collections, and
 # the 799 data lets their staff know which shelf (or range of shelves) to check for the call number in question.
-to_field 'sublocation_ssm', extract_marc('799a')
+to_field 'sublocation_ssm', extract_marc('799a') do |record, accumulator|
+  record.fields('857').each do |field|
+    field.each do |subfield|
+      if ark_prefix_match(subfield.value) && subfield.code == 'u'
+        accumulator << subfield.value
+      end
+    end
+  end
+end
 
 # IIIF Manifest url
 #

--- a/lib/psulib_traject/macros.rb
+++ b/lib/psulib_traject/macros.rb
@@ -70,6 +70,11 @@ module PsulibTraject
       url_match[1]
     end
 
+    # Returns a boolean of whether a given text contains our ARK prefix
+    def ark_prefix_match(text)
+      /^ark:\/42409/.match?(text)
+    end
+
     def link_domain(link)
       serial_solutions_link?(link) ? 'serialssolutions.com' : link
     end

--- a/spec/integration/macros_spec.rb
+++ b/spec/integration/macros_spec.rb
@@ -369,4 +369,24 @@ RSpec.describe 'Macros' do
       end
     end
   end
+
+  describe '#ark_prefix_match' do
+    let(:dummy) { Class.new { extend PsulibTraject::Macros } }
+
+    context 'when the value begins with our ark code' do
+      good_code = 'ark:/42409/abcdefg'
+
+      it 'returns true' do
+        expect(dummy.ark_prefix_match(good_code)).to be(true)
+      end
+    end
+
+    context 'when the value does not begins with our ark code' do
+      bad_code = 'smurf:/12345/abcdefg'
+
+      it 'returns false' do
+        expect(dummy.ark_prefix_match(bad_code)).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #503 
If 857 starts with our ark prefix, adds it to the sublocation ssm.