### PR TITLE
Add Dependabot configuration and update Ruby and JRuby versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@2.3.1
+  ruby: circleci/ruby@2.6.0
   docker: circleci/docker@2.8.2
 
 parameters:
@@ -31,13 +31,13 @@ parameters:
     default: "uldev"
   CLUSTERS_PROD:
     type: string
-    default: "prod"    
+    default: "prod"
   REGISTRY_HOST:
     type: string
-    default: "harbor.k8s.libraries.psu.edu"    
+    default: "harbor.k8s.libraries.psu.edu"
   PIPELINE_CONFIG_VERSION:
     type: string
-    default: "1.0.1"    
+    default: "1.0.1"
 
 commands:
 
@@ -62,7 +62,7 @@ commands:
               SLUG=$(slugify-branch "$CIRCLE_BRANCH")
               TAG="${SLUG}--$CIRCLE_SHA1"
             fi
-            echo "export TAG=$TAG" >> "$BASH_ENV"    
+            echo "export TAG=$TAG" >> "$BASH_ENV"
 
 executors:
 
@@ -82,7 +82,7 @@ jobs:
       REGISTRY_REPO: "library/$CIRCLE_PROJECT_REPONAME"
     executor:
       name: ci-utils
-      image_tag: << pipeline.parameters.CI_UTILS_IMAGE_TAG >>  
+      image_tag: << pipeline.parameters.CI_UTILS_IMAGE_TAG >>
       registry_host: << pipeline.parameters.REGISTRY_HOST >>
     steps:
       - setup_remote_docker:
@@ -110,7 +110,7 @@ jobs:
           paths:
             - docker-image.tar
             - docker-image-info
-  
+
   push-image:
     environment:
       REGISTRY_HOST: << pipeline.parameters.REGISTRY_HOST >>
@@ -135,7 +135,7 @@ jobs:
       - docker/push:
           image: $REGISTRY_REPO
           registry: $REGISTRY_HOST
-          tag: $TAG          
+          tag: $TAG
 
   release-image:
     parameters:
@@ -173,7 +173,7 @@ jobs:
               export TARGET_CLUSTER="$cluster"
               echo "Processing cluster: $TARGET_CLUSTER"
               /usr/local/bin/image-release-pr "clusters/$TARGET_CLUSTER/manifests/$CIRCLE_PROJECT_REPONAME/prod.yaml"
-            done          
+            done
 
 
   # release:
@@ -265,15 +265,15 @@ workflows:
           context:
             - org-global
           filters:
-            branches:              
+            branches:
               only:
                 - main
                 - /preview\/.*/
           requires:
             - build-image
             - test-application
-      
-      - release-image: 
+
+      - release-image:
           name: release-image
           clusters: << pipeline.parameters.CLUSTERS_PROD >>
           context:
@@ -284,7 +284,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v\d+\.\d+\.\d+.*/    
+              only: /^v\d+\.\d+\.\d+.*/
       # - release:
       #     context: org-global
       #     name: "Release Image"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ parameters:
     default: ""
   CI_UTILS_IMAGE_TAG:
     type: string
-    default: "v4.3.0"
+    default: "v4.6.2"
   CONFIG_REPO_NAME:
     type: string
     default: "catalog-config"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jruby:10.0.2.0
+FROM jruby:10.0.4.0
 WORKDIR /app
 ARG UID=3000
 


### PR DESCRIPTION
This pull request updates several dependencies and CI configurations to keep the project up-to-date and improve maintainability. The most significant changes include updating the JRuby base image, CircleCI Ruby orb, and Docker image tag, as well as introducing automated dependency management with Dependabot.

**Dependency and CI tool updates:**

* Updated the base image in `Dockerfile` from `jruby:10.0.2.0` to `jruby:10.0.4.0` to use a newer JRuby version.
* Upgraded the CircleCI Ruby orb from `circleci/ruby@2.3.1` to `circleci/ruby@2.6.0` in `.circleci/config.yml`.
* Updated the default `CI_UTILS_IMAGE_TAG` parameter from `v4.3.0` to `v4.6.2` in `.circleci/config.yml`.

**Automated dependency management:**

* Added a `.github/dependabot.yml` configuration to enable weekly automated updates for Docker and Bundler dependencies.